### PR TITLE
feat: Add monthly sales performance charts to dashboard

### DIFF
--- a/src/app/modules/dashboard.service.ts
+++ b/src/app/modules/dashboard.service.ts
@@ -1,65 +1,182 @@
 import { Injectable } from '@angular/core';
+import { ItemService } from '../services/item.service';
+import { Order } from '../model/order.model';
+// Product model might be needed if we enhance salesByProduct to use product names from product list
+// import { Product } from '../model/product.model';
+import { Observable, map, of } from 'rxjs';
+import { Timestamp } from '@angular/fire/firestore';
+import * as Highcharts from 'highcharts'; // Import Highcharts
 
 @Injectable({
   providedIn: 'root'
 })
 export class DashboardService {
 
-  constructor() { }
+  constructor(private itemService: ItemService) { }
 
-	bigChart() {
-		return [{
-			name: 'Asia',
-			data: [502, 635, 809, 947, 1402, 3634, 5268]
-		}, {
-			name: 'Africa',
-			data: [106, 107, 111, 133, 221, 767, 1766]
-		}, {
-			name: 'Europe',
-			data: [163, 203, 276, 408, 547, 729, 628]
-		}, {
-			name: 'America',
-			data: [18, 31, 54, 156, 339, 818, 1201]
-		}, {
-			name: 'Oceania',
-			data: [2, 2, 2, 6, 13, 30, 46]
-		}];
-	}
+  public getMonthlySalesAndOrdersData(): Observable<Highcharts.Options> {
+    return this.itemService.GetOrdersList().pipe(
+      map((orders: Order[]) => {
+        const monthlyData: { [monthKey: string]: { sales: number; count: number } } = {};
+        const monthYearFormat = new Intl.DateTimeFormat('en-US', { month: 'short', year: '2-digit' });
 
-	cards() {
-		return [71, 78, 39, 66];
-	}
+        // Initialize last 6 months
+        for (let i = 5; i >= 0; i--) {
+          const d = new Date();
+          d.setDate(1); // Start from the first day of the current month before going back
+          d.setMonth(d.getMonth() - i);
+          const monthKey = monthYearFormat.format(d);
+          monthlyData[monthKey] = { sales: 0, count: 0 };
+        }
 
-	pieChart() {
-		return [{
-			name: 'Chrome',
-			y: 61.41,
-			sliced: true,
-			selected: true
-		}, {
-			name: 'Internet Explorer',
-			y: 11.84
-		}, {
-			name: 'Firefox',
-			y: 10.85
-		}, {
-			name: 'Edge',
-			y: 4.67
-		}, {
-			name: 'Safari',
-			y: 4.18
-		}, {
-			name: 'Sogou Explorer',
-			y: 1.64
-		}, {
-			name: 'Opera',
-			y: 1.6
-		}, {
-			name: 'QQ',
-			y: 1.2
-		}, {
-			name: 'Other',
-			y: 2.61
-		}];
-	}
+        orders.forEach(order => {
+          let orderDate: Date | undefined;
+          if (order.created_date) {
+            if (order.created_date instanceof Timestamp) {
+                orderDate = order.created_date.toDate();
+            } else if (order.created_date instanceof Date) {
+                orderDate = order.created_date;
+            } else {
+                const parsedDate = new Date(order.created_date as any);
+                if (!isNaN(parsedDate.getTime())) {
+                    orderDate = parsedDate;
+                }
+            }
+          }
+
+          if (orderDate) {
+            const orderMonthKey = monthYearFormat.format(orderDate);
+            // Ensure this month is one of the 6 months we are tracking
+            if (monthlyData[orderMonthKey] && order.total_cost !== undefined && order.total_cost !== null) {
+              monthlyData[orderMonthKey].sales += order.total_cost;
+              monthlyData[orderMonthKey].count += 1;
+            }
+          }
+        });
+
+        const categories = Object.keys(monthlyData);
+        const salesData = categories.map(cat => monthlyData[cat].sales);
+        const ordersCountData = categories.map(cat => monthlyData[cat].count);
+
+        return {
+          chart: { type: 'area' },
+          title: { text: 'Monthly Sales and Orders (Last 6 Months)' },
+          xAxis: { categories: categories, title: { text: 'Month' } },
+          yAxis: [
+            { title: { text: 'Total Sales' }, labels: { formatter: function() { return '$' + Highcharts.numberFormat(this.value, 0, '.', ','); } } },
+            { title: { text: 'Number of Orders' }, opposite: true, labels: { format: '{value}'} }
+          ],
+          series: [
+            { name: 'Total Sales', type: 'area', data: salesData, yAxis: 0 },
+            { name: 'Number of Orders', type: 'line', data: ordersCountData, yAxis: 1 }
+          ],
+          tooltip: { shared: true, crosshairs: true },
+          credits: { enabled: false },
+          exporting: { enabled: true }
+        } as Highcharts.Options;
+      })
+    );
+  }
+
+  public getSalesByProductData(month?: Date): Observable<{ name: string; y: number }[]> {
+    const targetDate = month || new Date();
+    const targetYear = targetDate.getFullYear();
+    const targetMonth = targetDate.getMonth();
+
+    return this.itemService.GetOrdersList().pipe(
+        map((orders: Order[]) => {
+            const productSales: { [productKey: string]: { name: string; sales: number } } = {};
+
+            orders.forEach(order => {
+                let orderDate: Date | undefined;
+                if (order.created_date) {
+                    if (order.created_date instanceof Timestamp) {
+                        orderDate = order.created_date.toDate();
+                    } else if (order.created_date instanceof Date) {
+                        orderDate = order.created_date;
+                    } else {
+                        const parsedDate = new Date(order.created_date as any);
+                        if (!isNaN(parsedDate.getTime())) {
+                            orderDate = parsedDate;
+                        }
+                    }
+                }
+
+                if (orderDate && orderDate.getFullYear() === targetYear && orderDate.getMonth() === targetMonth) {
+                    if (order.items && Array.isArray(order.items)) {
+                        order.items.forEach((item: any) => {
+                            const productKey = item.product_no || 'Unknown Product';
+                            const itemName = item.product_name || item.name || productKey;
+                            const itemCost = (typeof item.item_cost === 'string' ? parseFloat(item.item_cost) : Number(item.item_cost)) || 0;
+
+                            if (productSales[productKey]) {
+                                productSales[productKey].sales += itemCost;
+                            } else {
+                                productSales[productKey] = { name: itemName, sales: itemCost };
+                            }
+                        });
+                    }
+                }
+            });
+            return Object.values(productSales).map(p => ({ name: p.name, y: p.sales }));
+        })
+    );
+  }
+
+  // --- Existing methods from the original file ---
+  bigChart() {
+    return [{
+        name: 'Asia',
+        data: [502, 635, 809, 947, 1402, 3634, 5268]
+    }, {
+        name: 'Africa',
+        data: [106, 107, 111, 133, 221, 767, 1766]
+    }, {
+        name: 'Europe',
+        data: [163, 203, 276, 408, 547, 729, 628]
+    }, {
+        name: 'America',
+        data: [18, 31, 54, 156, 339, 818, 1201]
+    }, {
+        name: 'Oceania',
+        data: [2, 2, 2, 6, 13, 30, 46]
+    }];
+  }
+
+  cards() {
+    return [71, 78, 39, 66];
+  }
+
+  pieChart() { // This is the original generic pie chart data
+    return [{
+        name: 'Chrome',
+        y: 61.41,
+        sliced: true,
+        selected: true
+    }, {
+        name: 'Internet Explorer',
+        y: 11.84
+    }, {
+        name: 'Firefox',
+        y: 10.85
+    }, {
+        name: 'Edge',
+        y: 4.67
+    }, {
+        name: 'Safari',
+        y: 4.18
+    }, {
+        name: 'Sogou Explorer',
+        y: 1.64
+    }, {
+        name: 'Opera',
+        y: 1.6
+    }, {
+        name: 'QQ',
+        y: 1.2
+    }, {
+        name: 'Other',
+        y: 2.61
+    }];
+  }
 }

--- a/src/app/modules/dashboard/dashboard.component.html
+++ b/src/app/modules/dashboard/dashboard.component.html
@@ -57,6 +57,31 @@
 
 <mat-divider></mat-divider>
 
+<!-- NEW CHARTS SECTION -->
+<div fxLayout="row" fxLayoutAlign="space-between start" fxLayoutGap="20px" style="margin-top: 20px; margin-bottom: 20px;">
+    <div fxFlex="60">
+        <mat-card *ngIf="monthlySalesChartOptions$ | async as options">
+            <mat-card-content>
+                <!-- Title for area chart is set within options by DashboardService -->
+                <app-widget-area [chartOptions]="options"></app-widget-area>
+            </mat-card-content>
+        </mat-card>
+    </div>
+    <div fxFlex="40">
+        <mat-card *ngIf="salesByProductData$ | async as pieData">
+            <mat-card-header>
+                <mat-card-title style="font-size: 18px; text-align: center; width: 100%;">Sales by Product (Current Month)</mat-card-title>
+            </mat-card-header>
+            <mat-card-content>
+                <app-widget-pie [data]="pieData"></app-widget-pie>
+            </mat-card-content>
+        </mat-card>
+    </div>
+</div>
+<!-- END NEW CHARTS SECTION -->
+
+<mat-divider></mat-divider>
+
 <div fxLayout="row" fxLayoutAlign="space-between center" fxLayoutGap="20px">
     <div fxFlex="60">
         <div class="mat-elevation-z8">


### PR DESCRIPTION
Implemented new charts in the admin dashboard to display sales performance:

1.  **Monthly Sales and Orders Chart (Area Chart):**
    *   Displays total sales and number of orders for the last 6 months.
    *   Data is fetched and processed by `DashboardService`, using `ItemService.GetOrdersList()`.
    *   Uses a dual-axis area chart for sales and a line chart for order counts.

2.  **Sales by Product Chart (Pie Chart):**
    *   Displays the proportion of sales attributed to each product for the current month.
    *   Data is processed by `DashboardService`, aggregating `item_cost` from orders.
    *   Product names are taken from order items (`product_name`, `name`, or `product_no` as fallback).

**Changes Made:**

*   **`DashboardService` (`dashboard.service.ts`):**
    *   Added `getMonthlySalesAndOrdersData()` to prepare data for the area chart.
    *   Added `getSalesByProductData()` to prepare data for the pie chart.
    *   Includes robust date handling and formatting for Highcharts.
*   **`DashboardComponent` (`dashboard.component.ts`):**
    *   Fetches data for the new charts from `DashboardService` via observables.
    *   Makes data available to the template using `async` pipe.
*   **`Dashboard Template` (`dashboard.component.html`):**
    *   Added `<app-widget-area>` and `<app-widget-pie>` components to display the new charts.
    *   New charts are placed in a new row within `mat-card` elements for consistent styling.
    *   A title "Sales by Product (Current Month)" is added for the new pie chart.

This enhancement provides administrators with a clearer visual overview of sales trends and product performance directly on the dashboard.