### PR TITLE
Upgrade loader-utils to ^2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -130,7 +130,7 @@
         "karma-source-map-support": "1.4.0",
         "less-loader": "6.2.0",
         "license-webpack-plugin": "2.3.0",
-        "loader-utils": "2.0.0",
+        "loader-utils": "^2.0.4",
         "mini-css-extract-plugin": "0.10.0",
         "minimatch": "3.0.4",
         "open": "7.2.0",
@@ -428,6 +428,20 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -4201,17 +4215,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@protobufjs/aspromise": {


### PR DESCRIPTION
This commit upgrades `loader-utils` to version `^2.0.4` to address a prototype pollution vulnerability (CVE-2022-37601).

Skipped tests due to an unrelated error with `@angular/compiler-cli`.