### PR TITLE
Fix: Override xml2js to non-vulnerable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16426,9 +16426,9 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "ts-node": "~10.9.0"
   },
   "overrides": {
-    "tough-cookie": "4.1.4"
+    "tough-cookie": "4.1.4",
+    "xml2js": "0.6.2"
   }
 }


### PR DESCRIPTION
Overrides xml2js to version 0.6.2 to remediate prototype pollution vulnerability.

Note: Existing unit and e2e tests are failing due to unrelated issues (TypeScript errors, Jest/Jasmine syntax conflicts, Protractor deprecation) and were not addressed in this change.