### PR TITLE
feat: Add framework for multiple external integrations

### DIFF
--- a/src/app/modules/integrations/amazon-connector/amazon-connector.component.html
+++ b/src/app/modules/integrations/amazon-connector/amazon-connector.component.html
@@ -1,0 +1,46 @@
+<div class="connector-container">
+  <h2>Amazon Integration</h2>
+
+  <div class="sync-section">
+    <button (click)="syncAmazonOrders()" [disabled]="isLoading" mat-raised-button color="primary">
+      <mat-icon>sync</mat-icon>
+      {{ isLoading ? 'Syncing Orders...' : 'Sync Amazon Orders' }}
+    </button>
+    <!-- Add buttons for product sync and inventory update if needed -->
+    <!--
+    <button (click)="syncAmazonProducts()" [disabled]="isLoading" mat-raised-button>
+      Sync Products
+    </button>
+    <button (click)="updateAmazonInventory()" [disabled]="isLoading" mat-raised-button>
+      Update Inventory
+    </button>
+    -->
+  </div>
+
+  <mat-progress-bar mode="indeterminate" *ngIf="isLoading"></mat-progress-bar>
+
+  <div class="sync-info" *ngIf="lastSyncTime">
+    <p>Last sync attempt: {{ lastSyncTime | date:'medium' }}</p>
+    <p>Orders Processed: {{ ordersProcessed }}</p>,
+    <p>Orders Failed: {{ ordersFailed }}</p>
+  </div>
+
+  <div *ngIf="errorMessages.length > 0" class="error-messages">
+    <h4>Sync Errors:</h4>
+    <ul>
+      <li *ngFor="let msg of errorMessages">{{ msg }}</li>
+    </ul>
+  </div>
+
+  <div class="integration-details">
+    <h3>Configuration (Placeholder)</h3>
+    <p>
+      Amazon integration allows you to sync orders from your Amazon Seller Central account.
+      Future enhancements will include product listing synchronization and inventory updates.
+    </p>
+    <p>
+      <em>Note: This integration currently uses mock data. Full API connectivity is pending.</em>
+    </p>
+    <!-- Placeholder for Amazon specific settings or status -->
+  </div>
+</div>

--- a/src/app/modules/integrations/amazon-connector/amazon-connector.component.scss
+++ b/src/app/modules/integrations/amazon-connector/amazon-connector.component.scss
@@ -1,0 +1,69 @@
+.connector-container {
+  padding: 20px;
+  max-width: 800px;
+  margin: auto;
+}
+
+.sync-section {
+  margin-bottom: 20px;
+  display: flex;
+  gap: 10px; /* Adds space between buttons */
+}
+
+.sync-section button {
+  margin-right: 10px; /* Kept for specific spacing if needed, but gap is often better */
+}
+
+mat-progress-bar {
+  margin-bottom: 20px;
+}
+
+.sync-info {
+  margin-top: 15px;
+  padding: 10px;
+  background-color: #f0f0f0;
+  border-radius: 4px;
+  border: 1px solid #e0e0e0;
+}
+
+.sync-info p {
+  margin: 5px 0;
+  font-size: 0.9em;
+}
+
+.error-messages {
+  margin-top: 15px;
+  padding: 10px;
+  background-color: #ffebee; /* Light red background for errors */
+  border: 1px solid #ef9a9a; /* Reddish border */
+  color: #c62828; /* Darker red text for contrast */
+  border-radius: 4px;
+}
+
+.error-messages h4 {
+  margin-top: 0;
+  color: #b71c1c; /* Even darker red for the heading */
+}
+
+.error-messages ul {
+  padding-left: 20px;
+  margin-bottom: 0;
+}
+
+.integration-details {
+  margin-top: 20px;
+  padding: 15px;
+  background-color: #e3f2fd; /* Light blue background */
+  border: 1px solid #90caf9; /* Bluish border */
+  border-radius: 4px;
+}
+
+.integration-details h3 {
+  margin-top: 0;
+  color: #0d47a1; /* Dark blue for heading */
+}
+
+/* Styling for Material icons in buttons if not already global */
+button mat-icon {
+  margin-right: 8px;
+}

--- a/src/app/modules/integrations/amazon-connector/amazon-connector.component.spec.ts
+++ b/src/app/modules/integrations/amazon-connector/amazon-connector.component.spec.ts
@@ -1,0 +1,175 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+
+import { AmazonConnectorComponent } from './amazon-connector.component';
+import { AmazonService } from '../../services/amazon.service';
+import { OrderService } from '../../services/order.service'; // Path corrected based on previous assumptions
+import { Order } from '../../model/order.model';
+
+// Material Module imports (minimal set for testing this component)
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatIconModule } from '@angular/material/icon';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+
+// Mock services
+class MockAmazonService {
+  fetchNewAmazonOrders = jasmine.createSpy('fetchNewAmazonOrders').and.returnValue(of([]));
+  syncProductListings = jasmine.createSpy('syncProductListings').and.returnValue(of(true));
+  updateInventory = jasmine.createSpy('updateInventory').and.returnValue(of(true));
+}
+
+class MockOrderService {
+  createOrder = jasmine.createSpy('createOrder').and.returnValue(Promise.resolve({id: 'order-123'}));
+}
+
+describe('AmazonConnectorComponent', () => {
+  let component: AmazonConnectorComponent;
+  let fixture: ComponentFixture<AmazonConnectorComponent>;
+  let amazonService: MockAmazonService;
+  let orderService: MockOrderService;
+
+  const mockOrder: Order = {
+    id: 'amz-order-1',
+    user_id: 'amazon-user',
+    customer_name: 'Test Customer',
+    items: [{ product_no: 'prod1', product_name: 'Product 1', quantity: 1, item_cost: 10 }],
+    total_cost: 10,
+    created_date: new Date().toISOString(),
+    delivery_address: '123 Test St',
+    payment_type: 'Credit Card',
+    delivery_cost: 0,
+    discount:0
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AmazonConnectorComponent],
+      imports: [
+        ReactiveFormsModule,
+        HttpClientTestingModule, // Though services are mocked, good to have if component ever used http directly
+        NoopAnimationsModule, // For Material animations
+        MatCardModule,
+        MatButtonModule,
+        MatProgressBarModule,
+        MatIconModule
+      ],
+      providers: [
+        { provide: AmazonService, useClass: MockAmazonService },
+        { provide: OrderService, useClass: MockOrderService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AmazonConnectorComponent);
+    component = fixture.componentInstance;
+    amazonService = TestBed.inject(AmazonService) as unknown as MockAmazonService;
+    orderService = TestBed.inject(OrderService) as unknown as MockOrderService;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('syncAmazonOrders', () => {
+    it('should set isLoading to true and reset messages/counters', () => {
+      component.syncAmazonOrders();
+      expect(component.isLoading).toBeTrue();
+      expect(component.ordersProcessed).toBe(0);
+      expect(component.ordersFailed).toBe(0);
+      expect(component.errorMessages.length).toBe(0);
+    });
+
+    it('should call amazonService.fetchNewAmazonOrders and process orders', fakeAsync(() => {
+      amazonService.fetchNewAmazonOrders.and.returnValue(of([mockOrder, mockOrder]));
+      orderService.createOrder.and.returnValue(Promise.resolve({id: 'new-id'}));
+
+      component.syncAmazonOrders();
+      tick(); // Allow promises and observables to resolve
+
+      expect(amazonService.fetchNewAmazonOrders).toHaveBeenCalled();
+      expect(orderService.createOrder).toHaveBeenCalledTimes(2);
+      expect(orderService.createOrder).toHaveBeenCalledWith(mockOrder);
+      expect(component.ordersProcessed).toBe(2);
+      expect(component.ordersFailed).toBe(0);
+      expect(component.isLoading).toBeFalse();
+      expect(component.lastSyncTime).not.toBeNull();
+    }));
+
+    it('should handle errors from fetchNewAmazonOrders', fakeAsync(() => {
+      amazonService.fetchNewAmazonOrders.and.returnValue(throwError(() => new Error('Fetch failed')));
+      component.syncAmazonOrders();
+      tick();
+
+      expect(component.errorMessages).toContain('Error fetching Amazon orders: Fetch failed');
+      expect(component.isLoading).toBeFalse();
+      expect(component.lastSyncTime).not.toBeNull();
+    }));
+
+    it('should handle errors from orderService.createOrder', fakeAsync(() => {
+      amazonService.fetchNewAmazonOrders.and.returnValue(of([mockOrder]));
+      orderService.createOrder.and.returnValue(Promise.reject(new Error('Create order failed')));
+
+      component.syncAmazonOrders();
+      tick(); // for observable
+      tick(); // for promise rejection
+
+      expect(component.ordersFailed).toBe(1);
+      expect(component.ordersProcessed).toBe(0);
+      expect(component.errorMessages.length).toBeGreaterThan(0);
+      expect(component.errorMessages[0]).toContain(`Failed to process Amazon order ${mockOrder.id}`);
+      expect(component.isLoading).toBeFalse();
+    }));
+
+     it('should handle empty orders array from fetchNewAmazonOrders', fakeAsync(() => {
+      amazonService.fetchNewAmazonOrders.and.returnValue(of([]));
+      component.syncAmazonOrders();
+      tick();
+
+      expect(component.errorMessages).toContain('No new Amazon orders found or an error occurred while fetching.');
+      expect(orderService.createOrder).not.toHaveBeenCalled();
+      expect(component.isLoading).toBeFalse();
+    }));
+  });
+
+  describe('syncAmazonProducts', () => {
+    it('should call amazonService.syncProductListings', fakeAsync(() => {
+      amazonService.syncProductListings.and.returnValue(of(true));
+      component.syncAmazonProducts();
+      tick();
+      expect(amazonService.syncProductListings).toHaveBeenCalledWith([]); // Expects empty array as per current component code
+      expect(component.isLoading).toBeFalse();
+    }));
+
+    it('should handle failure from syncProductListings', fakeAsync(() => {
+      amazonService.syncProductListings.and.returnValue(of(false));
+      component.syncAmazonProducts();
+      tick();
+      expect(component.errorMessages).toContain('Failed to sync Amazon products.');
+      expect(component.isLoading).toBeFalse();
+    }));
+  });
+
+    describe('updateAmazonInventory', () => {
+    it('should call amazonService.updateInventory', fakeAsync(() => {
+      amazonService.updateInventory.and.returnValue(of(true));
+      component.updateAmazonInventory();
+      tick();
+      expect(amazonService.updateInventory).toHaveBeenCalledWith([]); // Expects empty array
+      expect(component.isLoading).toBeFalse();
+    }));
+
+    it('should handle failure from updateInventory', fakeAsync(() => {
+      amazonService.updateInventory.and.returnValue(of(false));
+      component.updateAmazonInventory();
+      tick();
+      expect(component.errorMessages).toContain('Failed to update Amazon inventory.');
+      expect(component.isLoading).toBeFalse();
+    }));
+  });
+
+});

--- a/src/app/modules/integrations/amazon-connector/amazon-connector.component.ts
+++ b/src/app/modules/integrations/amazon-connector/amazon-connector.component.ts
@@ -1,0 +1,106 @@
+import { Component, OnInit } from '@angular/core';
+import { AmazonService } from '../../services/amazon.service';
+import { OrderService } from '../../services/order.service'; // Assuming OrderService is in modules/services
+import { Order } from '../../model/order.model';
+
+@Component({
+  selector: 'app-amazon-connector',
+  templateUrl: './amazon-connector.component.html',
+  styleUrls: ['./amazon-connector.component.scss']
+})
+export class AmazonConnectorComponent implements OnInit {
+  isLoading: boolean = false;
+  ordersProcessed: number = 0;
+  ordersFailed: number = 0;
+  lastSyncTime: Date | null = null;
+  errorMessages: string[] = [];
+
+  constructor(
+    private amazonService: AmazonService,
+    private orderService: OrderService // To save/process orders into the main system
+  ) { }
+
+  ngOnInit(): void {
+  }
+
+  /**
+   * Initiates the synchronization process for Amazon orders.
+   */
+  async syncAmazonOrders(): Promise<void> {
+    this.isLoading = true;
+    this.ordersProcessed = 0;
+    this.ordersFailed = 0;
+    this.errorMessages = [];
+
+    this.amazonService.fetchNewAmazonOrders().subscribe(
+      async (orders: Order[]) => {
+        if (orders && orders.length > 0) {
+          for (const order of orders) {
+            try {
+              // Ensure items array exists (it should be handled by the transformation, but good practice)
+              if (!order.items) {
+                order.items = [];
+              }
+              await this.orderService.createOrder(order); // Assuming createOrder exists
+              this.ordersProcessed++;
+            } catch (error: any) {
+              this.ordersFailed++;
+              const errorMessage = `Failed to process Amazon order ${order.id || 'N/A'}: ${error.message || error}`;
+              console.error(errorMessage, error);
+              this.errorMessages.push(errorMessage);
+            }
+          }
+        } else {
+          this.errorMessages.push('No new Amazon orders found or an error occurred while fetching.');
+        }
+        this.isLoading = false;
+        this.lastSyncTime = new Date();
+      },
+      (error: any) => {
+        console.error('Error fetching Amazon orders:', error);
+        this.errorMessages.push(`Error fetching Amazon orders: ${error.message || error}`);
+        this.isLoading = false;
+        this.lastSyncTime = new Date(); // Record sync attempt time even on fetch error
+      }
+    );
+  }
+
+  // Placeholder methods for other Amazon functionalities
+  syncAmazonProducts(): void {
+    this.isLoading = true;
+    this.errorMessages = [];
+    this.amazonService.syncProductListings([] /* pass actual products here */).subscribe(
+      (success) => {
+        if (success) {
+          // Handle success - maybe a success message
+        } else {
+          this.errorMessages.push('Failed to sync Amazon products.');
+        }
+        this.isLoading = false;
+      },
+      (error: any) => {
+        this.errorMessages.push(`Error syncing Amazon products: ${error.message || error}`);
+        this.isLoading = false;
+      }
+    );
+  }
+
+  updateAmazonInventory(): void {
+    this.isLoading = true;
+    this.errorMessages = [];
+    this.amazonService.updateInventory([] /* pass actual inventory updates here */).subscribe(
+      (success) => {
+        if (success) {
+          // Handle success
+        } else {
+          this.errorMessages.push('Failed to update Amazon inventory.');
+        }
+        this.isLoading = false;
+      },
+      (error: any) => {
+        this.errorMessages.push(`Error updating Amazon inventory: ${error.message || error}`);
+        this.isLoading = false;
+      }
+    );
+  }
+}

--- a/src/app/modules/integrations/ebay-connector/ebay-connector.component.html
+++ b/src/app/modules/integrations/ebay-connector/ebay-connector.component.html
@@ -1,15 +1,27 @@
 <div class="container mt-4">
   <mat-card>
     <mat-card-header>
-      <mat-card-title>eBay Order Synchronization</mat-card-title>
-      <mat-card-subtitle>Fetch new orders from eBay and add them to the system.</mat-card-subtitle>
+      <mat-card-title>eBay Integration Management</mat-card-title>
+      <mat-card-subtitle>Manage orders, products, and inventory with eBay.</mat-card-subtitle>
     </mat-card-header>
     <mat-card-content>
-      <button mat-raised-button color="primary" (click)="syncEbayOrders()" [disabled]="isLoading">
-        <mat-icon *ngIf="!isLoading">sync</mat-icon>
-        <mat-progress-spinner *ngIf="isLoading" mode="indeterminate" diameter="20" class="mr-2"></mat-progress-spinner>
-        {{ isLoading ? 'Syncing...' : 'Sync New eBay Orders' }}
-      </button>
+      <div class="button-group">
+        <button mat-raised-button color="primary" (click)="syncEbayOrders()" [disabled]="isLoading" class="mr-2">
+          <mat-icon *ngIf="!isLoading">sync</mat-icon>
+          <mat-progress-spinner *ngIf="isLoading" mode="indeterminate" diameter="20" class="button-spinner"></mat-progress-spinner>
+          {{ isLoading ? 'Syncing...' : 'Sync eBay Orders' }}
+        </button>
+        <button mat-raised-button (click)="syncEbayProducts()" [disabled]="isLoading" class="mr-2">
+          <mat-icon *ngIf="!isLoading">cloud_upload</mat-icon>
+          <mat-progress-spinner *ngIf="isLoading" mode="indeterminate" diameter="20" class="button-spinner"></mat-progress-spinner>
+          {{ isLoading ? 'Syncing...' : 'Sync eBay Products' }}
+        </button>
+        <button mat-raised-button (click)="updateEbayInventory()" [disabled]="isLoading">
+          <mat-icon *ngIf="!isLoading">inventory_2</mat-icon>
+          <mat-progress-spinner *ngIf="isLoading" mode="indeterminate" diameter="20" class="button-spinner"></mat-progress-spinner>
+          {{ isLoading ? 'Updating...' : 'Update eBay Inventory' }}
+        </button>
+      </div>
 
       <div *ngIf="lastSyncTime" class="mt-3">
         <p><strong>Last Sync Attempt:</strong> {{ lastSyncTime | date:'medium' }}</p>

--- a/src/app/modules/integrations/ebay-connector/ebay-connector.component.ts
+++ b/src/app/modules/integrations/ebay-connector/ebay-connector.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { EbayService } from '../../services/ebay.service';
-import { OrderService } from '../../services/order.service'; // Changed ItemService to OrderService
+import { EbayService } from '../../modules/services/ebay.service'; // Corrected path
+import { OrderService } from '../../modules/services/order.service'; // Path was already corrected
 import { Order } from '../../model/order.model'; // Ensure this path is correct
 
 @Component({
@@ -66,6 +66,51 @@ export class EbayConnectorComponent implements OnInit {
         this.errorMessages.push(`Error fetching eBay orders: ${error.message || error}`);
         this.isLoading = false;
         this.lastSyncTime = new Date();
+      }
+    );
+  }
+
+  // Placeholder methods for other eBay functionalities
+  syncEbayProducts(): void {
+    this.isLoading = true;
+    this.errorMessages = []; // Clear previous errors
+    // Potentially add specific product processing counters if needed
+    this.ebayService.syncProductListings([] /* pass actual products from your app here */).subscribe(
+      (success) => {
+        if (success) {
+          // Handle success - maybe a success message or update UI
+          // e.g., this.productSyncSuccessMessage = "Products synced successfully!";
+          console.log('Ebay products synced successfully.');
+        } else {
+          this.errorMessages.push('Failed to sync eBay products.');
+        }
+        this.isLoading = false;
+      },
+      (error: any) => {
+        this.errorMessages.push(`Error syncing eBay products: ${error.message || error}`);
+        this.isLoading = false;
+      }
+    );
+  }
+
+  updateEbayInventory(): void {
+    this.isLoading = true;
+    this.errorMessages = []; // Clear previous errors
+    // Potentially add specific inventory update counters if needed
+    this.ebayService.updateInventory([] /* pass actual inventory updates from your app here */).subscribe(
+      (success) => {
+        if (success) {
+          // Handle success - maybe a success message or update UI
+          // e.g., this.inventoryUpdateMessage = "Inventory updated successfully!";
+          console.log('Ebay inventory updated successfully.');
+        } else {
+          this.errorMessages.push('Failed to update eBay inventory.');
+        }
+        this.isLoading = false;
+      },
+      (error: any) => {
+        this.errorMessages.push(`Error updating eBay inventory: ${error.message || error}`);
+        this.isLoading = false;
       }
     );
   }

--- a/src/app/modules/integrations/fedex-connector/fedex-connector.component.html
+++ b/src/app/modules/integrations/fedex-connector/fedex-connector.component.html
@@ -1,0 +1,145 @@
+<div class="connector-container">
+  <h2>FedEx Shipping Integration</h2>
+
+  <!-- Error Messages -->
+  <div *ngIf="errorMessages.length > 0" class="error-messages alert alert-danger">
+    <h4>Errors:</h4>
+    <ul>
+      <li *ngFor="let msg of errorMessages">{{ msg }}</li>
+    </ul>
+  </div>
+
+  <!-- Get Rates Section -->
+  <mat-card class="mb-3">
+    <mat-card-header>
+      <mat-card-title>Get Shipping Rates</mat-card-title>
+    </mat-card-header>
+    <mat-card-content [formGroup]="rateForm">
+      <div class="row">
+        <div class="col-md-6">
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Shipper Postal Code</mat-label>
+            <input matInput formControlName="shipperPostalCode">
+          </mat-form-field>
+        </div>
+        <div class="col-md-6">
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Shipper Country Code</mat-label>
+            <input matInput formControlName="shipperCountryCode">
+          </mat-form-field>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-6">
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Recipient Postal Code</mat-label>
+            <input matInput formControlName="recipientPostalCode">
+          </mat-form-field>
+        </div>
+        <div class="col-md-6">
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Recipient Country Code</mat-label>
+            <input matInput formControlName="recipientCountryCode">
+          </mat-form-field>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-6">
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Package Weight</mat-label>
+            <input matInput type="number" formControlName="packageWeight">
+          </mat-form-field>
+        </div>
+        <div class="col-md-6">
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Weight Units</mat-label>
+            <mat-select formControlName="packageWeightUnits">
+              <mat-option value="LB">LB</mat-option>
+              <mat-option value="KG">KG</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+      </div>
+      <button mat-raised-button color="primary" (click)="getRates()" [disabled]="isLoadingRates || rateForm.invalid">
+        <mat-icon>calculate</mat-icon>
+        {{ isLoadingRates ? 'Calculating...' : 'Get Rates' }}
+      </button>
+    </mat-card-content>
+    <mat-card-actions *ngIf="isLoadingRates">
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+    </mat-card-actions>
+    <div *ngIf="rates.length > 0 && !isLoadingRates" class="mt-3 results-section">
+      <h4>Available Rates (Mock):</h4>
+      <ul class="list-group">
+        <li *ngFor="let rate of rates" class="list-group-item">
+          {{ rate.serviceName }}: {{ rate.totalNetCharge | currency:rate.currency }}
+          <span *ngIf="rate.deliveryTimestamp"> (Est. Delivery: {{ rate.deliveryTimestamp | date:'shortDate' }})</span>
+        </li>
+      </ul>
+    </div>
+  </mat-card>
+
+  <!-- Create Label Section -->
+  <mat-card class="mb-3">
+    <mat-card-header>
+      <mat-card-title>Create Shipping Label</mat-card-title>
+    </mat-card-header>
+    <mat-card-content [formGroup]="labelForm">
+      <p class="text-muted small">Uses address and weight info from the "Get Rates" form for this mock. Select a service type (normally from rates result).</p>
+       <mat-form-field appearance="fill" class="w-100">
+            <mat-label>FedEx Service Type</mat-label>
+            <mat-select formControlName="serviceType">
+              <mat-option value="FEDEX_GROUND">FedEx Ground</mat-option>
+              <mat-option value="PRIORITY_OVERNIGHT">FedEx Priority Overnight</mat-option>
+              <mat-option value="FEDEX_2_DAY">FedEx 2Day</mat-option>
+              <!-- Add other common FedEx services -->
+            </mat-select>
+        </mat-form-field>
+      <button mat-raised-button color="accent" (click)="createLabel()" [disabled]="isLoadingLabel || labelForm.invalid || rateForm.invalid">
+        <mat-icon>receipt_long</mat-icon>
+        {{ isLoadingLabel ? 'Creating...' : 'Create Label' }}
+      </button>
+    </mat-card-content>
+    <mat-card-actions *ngIf="isLoadingLabel">
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+    </mat-card-actions>
+    <div *ngIf="labelInfo && !isLoadingLabel" class="mt-3 results-section">
+      <h4>Label Created (Mock):</h4>
+      <p>Tracking Number: <strong>{{ labelInfo.trackingNumber }}</strong></p>
+      <div *ngIf="labelPreviewUrl">
+        <p>Label Preview (PNG):</p>
+        <img [src]="labelPreviewUrl" alt="Shipping Label Preview" class="img-fluid label-preview">
+      </div>
+    </div>
+  </mat-card>
+
+  <!-- Track Package Section -->
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Track Package</mat-card-title>
+    </mat-card-header>
+    <mat-card-content [formGroup]="trackingForm">
+      <mat-form-field appearance="fill" class="w-100">
+        <mat-label>Tracking Number</mat-label>
+        <input matInput formControlName="trackingNumber">
+      </mat-form-field>
+      <button mat-raised-button color="warn" (click)="trackPackage()" [disabled]="isLoadingTracking || trackingForm.invalid">
+        <mat-icon>pin_drop</mat-icon>
+        {{ isLoadingTracking ? 'Tracking...' : 'Track Package' }}
+      </button>
+    </mat-card-content>
+    <mat-card-actions *ngIf="isLoadingTracking">
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+    </mat-card-actions>
+    <div *ngIf="trackingInfo && !isLoadingTracking" class="mt-3 results-section">
+      <h4>Tracking Information (Mock):</h4>
+      <p>Status: <strong>{{ trackingInfo.status }}</strong></p>
+      <p>Latest Event: {{ trackingInfo.latestEvent.eventDescription }} at {{ trackingInfo.latestEvent.address.city }} on {{ trackingInfo.latestEvent.timestamp | date:'medium' }}</p>
+      <p *ngIf="trackingInfo.estimatedDeliveryTimestamp">Estimated Delivery: {{ trackingInfo.estimatedDeliveryTimestamp | date:'mediumDate' }}</p>
+    </div>
+  </mat-card>
+
+   <div class="integration-details mt-4">
+    <p><em>Note: This FedEx integration currently uses mock data and simulates API calls. Full API connectivity is pending. Address information for label creation is simplified and currently sourced from the rate request form for this demo.</em></p>
+  </div>
+</div>

--- a/src/app/modules/integrations/fedex-connector/fedex-connector.component.scss
+++ b/src/app/modules/integrations/fedex-connector/fedex-connector.component.scss
@@ -1,0 +1,138 @@
+.connector-container {
+  padding: 20px;
+  max-width: 900px;
+  margin: auto;
+}
+
+mat-card {
+  margin-bottom: 20px; /* Spacing between cards */
+}
+
+.w-100 {
+  width: 100%;
+}
+
+.mb-3 {
+  margin-bottom: 1rem !important;
+}
+
+.mt-3 {
+  margin-top: 1rem !important;
+}
+
+.mt-4 {
+  margin-top: 1.5rem !important;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -15px;
+  margin-left: -15px;
+}
+
+.col-md-6 {
+  position: relative;
+  width: 100%;
+  padding-right: 15px;
+  padding-left: 15px;
+  flex: 0 0 50%;
+  max-width: 50%;
+}
+
+button mat-icon {
+  margin-right: 8px;
+}
+
+mat-progress-bar {
+  margin-top: 10px; /* Space above progress bar in card actions */
+}
+
+.results-section {
+  padding: 15px;
+  background-color: #f8f9fa;
+  border-radius: 4px;
+  border: 1px solid #e9ecef;
+}
+
+.results-section h4 {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.error-messages {
+  margin-bottom: 15px; // Keep some space if errors are shown at the top
+}
+
+.error-messages h4 {
+  margin-top: 0;
+}
+
+.error-messages ul {
+  padding-left: 20px;
+  margin-bottom: 0;
+}
+
+.label-preview {
+  max-width: 100%;
+  height: auto;
+  border: 1px solid #ccc;
+  margin-top: 10px;
+}
+
+.integration-details {
+  padding: 15px;
+  background-color: #fff3e0; /* Light orange/FedEx related color */
+  border: 1px solid #ffe0b2;
+  border-radius: 4px;
+  font-size: 0.9em;
+  color: #5f4006;
+}
+
+/* Basic alert styling if not globally available via Bootstrap */
+.alert {
+  position: relative;
+  padding: .75rem 1.25rem;
+  margin-bottom: 1rem;
+  border: 1px solid transparent;
+  border-radius: .25rem;
+}
+.alert-danger {
+  color: #721c24;
+  background-color: #f8d7da;
+  border-color: #f5c6cb;
+}
+
+/* Basic list group styling */
+.list-group {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0;
+  margin-bottom: 0;
+}
+.list-group-item {
+  position: relative;
+  display: block;
+  padding: .75rem 1.25rem;
+  background-color: #fff;
+  border: 1px solid rgba(0,0,0,.125);
+}
+.list-group-item:first-child {
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+}
+.list-group-item:last-child {
+  border-bottom-right-radius: inherit;
+  border-bottom-left-radius: inherit;
+  margin-bottom: -1px; // Overlap borders
+}
+.list-group-item + .list-group-item {
+  border-top-width: 0;
+}
+.text-muted {
+    color: #6c757d !important;
+}
+.small {
+    font-size: 80%;
+    font-weight: 400;
+}

--- a/src/app/modules/integrations/fedex-connector/fedex-connector.component.spec.ts
+++ b/src/app/modules/integrations/fedex-connector/fedex-connector.component.spec.ts
@@ -1,0 +1,185 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+
+import { FedexConnectorComponent } from './fedex-connector.component';
+import { FedExService } from '../../services/fedex.service';
+
+// Material Modules
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list'; // For displaying rates
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+// Mock FedExService
+class MockFedExService {
+  getShippingRates = jasmine.createSpy('getShippingRates').and.returnValue(of([]));
+  createShippingLabel = jasmine.createSpy('createShippingLabel').and.returnValue(of(null));
+  trackShipment = jasmine.createSpy('trackShipment').and.returnValue(of(null));
+}
+
+describe('FedexConnectorComponent', () => {
+  let component: FedexConnectorComponent;
+  let fixture: ComponentFixture<FedexConnectorComponent>;
+  let fedexService: MockFedExService;
+
+  const mockRatesResponse = [{ serviceName: 'FedEx Ground', totalNetCharge: 15.50, currency: 'USD' }];
+  const mockLabelResponse = { trackingNumber: 'FX12345', labelImageBase64: 'base64string==' };
+  const mockTrackingResponse = { trackingNumber: 'FX12345', status: 'IN_TRANSIT', latestEvent: { timestamp: '', eventDescription: 'Departed', address: {} } };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [FedexConnectorComponent],
+      imports: [
+        ReactiveFormsModule,
+        NoopAnimationsModule,
+        MatCardModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatSelectModule,
+        MatButtonModule,
+        MatProgressBarModule,
+        MatIconModule,
+        MatListModule
+      ],
+      providers: [
+        { provide: FedExService, useClass: MockFedExService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FedexConnectorComponent);
+    component = fixture.componentInstance;
+    fedexService = TestBed.inject(FedExService) as unknown as MockFedExService;
+    fixture.detectChanges(); // Initial binding
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('getRates', () => {
+    it('should not call service if rateForm is invalid', () => {
+      component.rateForm.controls['shipperPostalCode'].setValue(''); // Make form invalid
+      component.getRates();
+      expect(fedexService.getShippingRates).not.toHaveBeenCalled();
+      expect(component.errorMessages).toContain('Rate form is invalid. Please check the fields.');
+    });
+
+    it('should call fedexService.getShippingRates and populate rates if form is valid', fakeAsync(() => {
+      fedexService.getShippingRates.and.returnValue(of(mockRatesResponse));
+      // Form is valid by default in this setup
+      component.getRates();
+      tick();
+
+      expect(fedexService.getShippingRates).toHaveBeenCalled();
+      expect(component.rates.length).toBe(1);
+      expect(component.rates[0].serviceName).toBe('FedEx Ground');
+      expect(component.isLoadingRates).toBeFalse();
+    }));
+
+    it('should handle empty rates response', fakeAsync(() => {
+      fedexService.getShippingRates.and.returnValue(of([]));
+      component.getRates();
+      tick();
+      expect(component.rates.length).toBe(0);
+      expect(component.errorMessages).toContain('No rates returned from FedEx (mock).');
+      expect(component.isLoadingRates).toBeFalse();
+    }));
+
+    it('should handle error from getShippingRates', fakeAsync(() => {
+      fedexService.getShippingRates.and.returnValue(throwError(() => new Error('Rate API Down')));
+      component.getRates();
+      tick();
+      expect(component.errorMessages).toContain('Error fetching rates: Rate API Down');
+      expect(component.isLoadingRates).toBeFalse();
+    }));
+  });
+
+  describe('createLabel', () => {
+    it('should not call service if labelForm or rateForm is invalid', () => {
+      component.labelForm.controls['serviceType'].setValue(''); // Make labelForm invalid
+      component.createLabel();
+      expect(fedexService.createShippingLabel).not.toHaveBeenCalled();
+      expect(component.errorMessages).toContain('Label form is invalid.');
+
+      component.labelForm.controls['serviceType'].setValue('FEDEX_GROUND'); // Valid
+      component.rateForm.controls['shipperPostalCode'].setValue(''); // Make rateForm invalid
+      component.createLabel();
+      expect(fedexService.createShippingLabel).not.toHaveBeenCalledTimes(2); // Not called again
+    });
+
+    it('should call fedexService.createShippingLabel and set labelInfo/labelPreviewUrl', fakeAsync(() => {
+      fedexService.createShippingLabel.and.returnValue(of(mockLabelResponse));
+      component.createLabel(); // Assuming forms are valid
+      tick();
+
+      expect(fedexService.createShippingLabel).toHaveBeenCalled();
+      expect(component.labelInfo).toEqual(mockLabelResponse);
+      expect(component.labelPreviewUrl).toBe('data:image/png;base64,' + mockLabelResponse.labelImageBase64);
+      expect(component.isLoadingLabel).toBeFalse();
+    }));
+
+     it('should handle null response from createShippingLabel', fakeAsync(() => {
+      fedexService.createShippingLabel.and.returnValue(of(null));
+      component.createLabel();
+      tick();
+      expect(component.labelInfo).toBeNull();
+      expect(component.labelPreviewUrl).toBeNull();
+      expect(component.errorMessages).toContain('No label data returned from FedEx (mock).');
+      expect(component.isLoadingLabel).toBeFalse();
+    }));
+
+
+    it('should handle error from createShippingLabel', fakeAsync(() => {
+      fedexService.createShippingLabel.and.returnValue(throwError(() => new Error('Label API Down')));
+      component.createLabel();
+      tick();
+      expect(component.errorMessages).toContain('Error creating label: Label API Down');
+      expect(component.isLoadingLabel).toBeFalse();
+    }));
+  });
+
+  describe('trackPackage', () => {
+    it('should not call service if trackingForm is invalid', () => {
+      component.trackingForm.controls['trackingNumber'].setValue('');
+      component.trackPackage();
+      expect(fedexService.trackShipment).not.toHaveBeenCalled();
+      expect(component.errorMessages).toContain('Tracking form is invalid.');
+    });
+
+    it('should call fedexService.trackShipment and set trackingInfo', fakeAsync(() => {
+      fedexService.trackShipment.and.returnValue(of(mockTrackingResponse));
+      component.trackingForm.controls['trackingNumber'].setValue('12345');
+      component.trackPackage();
+      tick();
+
+      expect(fedexService.trackShipment).toHaveBeenCalledWith({ trackingNumber: '12345' });
+      expect(component.trackingInfo).toEqual(mockTrackingResponse);
+      expect(component.isLoadingTracking).toBeFalse();
+    }));
+
+    it('should handle null response from trackShipment', fakeAsync(() => {
+      fedexService.trackShipment.and.returnValue(of(null));
+      component.trackingForm.controls['trackingNumber'].setValue('12345');
+      component.trackPackage();
+      tick();
+      expect(component.trackingInfo).toBeNull();
+      expect(component.errorMessages).toContain('No tracking data returned from FedEx (mock).');
+      expect(component.isLoadingTracking).toBeFalse();
+    }));
+
+    it('should handle error from trackShipment', fakeAsync(() => {
+      fedexService.trackShipment.and.returnValue(throwError(() => new Error('Track API Down')));
+       component.trackingForm.controls['trackingNumber'].setValue('12345');
+      component.trackPackage();
+      tick();
+      expect(component.errorMessages).toContain('Error tracking package: Track API Down');
+      expect(component.isLoadingTracking).toBeFalse();
+    }));
+  });
+});

--- a/src/app/modules/integrations/fedex-connector/fedex-connector.component.ts
+++ b/src/app/modules/integrations/fedex-connector/fedex-connector.component.ts
@@ -1,0 +1,169 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FedExService } from '../../services/fedex.service'; // Assuming service in modules/services
+
+// Re-declare interfaces or import from service if they were exported
+interface FedExRateRequest {
+  shipperAddress: any;
+  recipientAddress: any;
+  packages: Array<{ weight: { value: number, units: 'LB' | 'KG' } }>;
+}
+interface FedExRateResponse {
+  serviceName: string;
+  totalNetCharge: number;
+  currency: string;
+  deliveryTimestamp?: string;
+}
+interface FedExLabelResponse {
+  trackingNumber: string;
+  labelImageBase64: string;
+}
+interface FedExTrackingResponse {
+  trackingNumber: string;
+  status: string;
+  latestEvent: { timestamp: string; eventDescription: string; address: any; };
+  estimatedDeliveryTimestamp?: string;
+}
+
+@Component({
+  selector: 'app-fedex-connector',
+  templateUrl: './fedex-connector.component.html',
+  styleUrls: ['./fedex-connector.component.scss']
+})
+export class FedexConnectorComponent implements OnInit {
+  isLoadingRates = false;
+  isLoadingLabel = false;
+  isLoadingTracking = false;
+
+  rateForm: FormGroup;
+  labelForm: FormGroup; // Simplified for now
+  trackingForm: FormGroup;
+
+  rates: FedExRateResponse[] = [];
+  labelInfo: FedExLabelResponse | null = null;
+  trackingInfo: FedExTrackingResponse | null = null;
+  labelPreviewUrl: string | null = null;
+
+  errorMessages: string[] = [];
+
+  constructor(private fb: FormBuilder, private fedexService: FedExService) {
+    this.rateForm = this.fb.group({
+      shipperPostalCode: ['90210', Validators.required],
+      shipperCountryCode: ['US', Validators.required],
+      recipientPostalCode: ['10001', Validators.required],
+      recipientCountryCode: ['US', Validators.required],
+      packageWeight: [5, [Validators.required, Validators.min(0.1)]],
+      packageWeightUnits: ['LB', Validators.required]
+    });
+
+    // Simplified label form for demonstration
+    this.labelForm = this.fb.group({
+      serviceType: ['FEDEX_GROUND', Validators.required] // This would come from selected rate
+      // In a real app, more fields from rateForm/selectedRate would be used
+    });
+
+    this.trackingForm = this.fb.group({
+      trackingNumber: ['', Validators.required]
+    });
+  }
+
+  ngOnInit(): void { }
+
+  getRates(): void {
+    if (this.rateForm.invalid) {
+      this.errorMessages = ['Rate form is invalid. Please check the fields.'];
+      return;
+    }
+    this.isLoadingRates = true;
+    this.rates = [];
+    this.errorMessages = [];
+
+    const formValue = this.rateForm.value;
+    const rateRequest: FedExRateRequest = {
+      shipperAddress: { postalCode: formValue.shipperPostalCode, countryCode: formValue.shipperCountryCode },
+      recipientAddress: { postalCode: formValue.recipientPostalCode, countryCode: formValue.recipientCountryCode },
+      packages: [{ weight: { value: formValue.packageWeight, units: formValue.packageWeightUnits } }]
+    };
+
+    this.fedexService.getShippingRates(rateRequest).subscribe(
+      (response) => {
+        this.rates = response;
+        if (this.rates.length === 0) {
+          this.errorMessages.push('No rates returned from FedEx (mock).');
+        }
+        this.isLoadingRates = false;
+      },
+      (err) => {
+        this.errorMessages.push(`Error fetching rates: ${err.message || err}`);
+        this.isLoadingRates = false;
+      }
+    );
+  }
+
+  createLabel(): void {
+    // This is highly simplified. A real scenario would use more comprehensive address data
+    // and selected rate information.
+    if (this.labelForm.invalid) {
+      this.errorMessages = ['Label form is invalid.'];
+      return;
+    }
+    this.isLoadingLabel = true;
+    this.labelInfo = null;
+    this.labelPreviewUrl = null;
+    this.errorMessages = [];
+
+    // Example: Constructing a more complete (but still mock-level) label request
+    const rateFormValue = this.rateForm.value; // Assuming rate form has relevant addresses
+    const labelFormValue = this.labelForm.value;
+
+    const labelRequest = {
+      shipper: { name: 'Sender Name', street: '123 Main St', city: 'Beverly Hills', stateCode: 'CA', postalCode: rateFormValue.shipperPostalCode, countryCode: rateFormValue.shipperCountryCode, phone: '1234567890' },
+      recipient: { name: 'Recipient Name', street: '456 Market St', city: 'New York', stateCode: 'NY', postalCode: rateFormValue.recipientPostalCode, countryCode: rateFormValue.recipientCountryCode, phone: '9876543210' },
+      serviceType: labelFormValue.serviceType,
+      packagingType: 'YOUR_PACKAGING',
+      packages: [{ weight: { value: rateFormValue.packageWeight, units: rateFormValue.packageWeightUnits } }],
+      labelSpecification: { imageType: 'PNG', labelStockType: 'PAPER_4X6' } // Request PNG for preview
+    };
+
+    this.fedexService.createShippingLabel(labelRequest as any).subscribe( // Cast as any due to simplified interface
+      (response) => {
+        this.labelInfo = response;
+        if (response && response.labelImageBase64) {
+          this.labelPreviewUrl = 'data:image/png;base64,' + response.labelImageBase64;
+        } else if (!response) {
+            this.errorMessages.push('No label data returned from FedEx (mock).');
+        }
+        this.isLoadingLabel = false;
+      },
+      (err) => {
+        this.errorMessages.push(`Error creating label: ${err.message || err}`);
+        this.isLoadingLabel = false;
+      }
+    );
+  }
+
+  trackPackage(): void {
+    if (this.trackingForm.invalid) {
+      this.errorMessages = ['Tracking form is invalid.'];
+      return;
+    }
+    this.isLoadingTracking = true;
+    this.trackingInfo = null;
+    this.errorMessages = [];
+    const formValue = this.trackingForm.value;
+
+    this.fedexService.trackShipment({ trackingNumber: formValue.trackingNumber }).subscribe(
+      (response) => {
+        this.trackingInfo = response;
+         if (!response) {
+            this.errorMessages.push('No tracking data returned from FedEx (mock).');
+        }
+        this.isLoadingTracking = false;
+      },
+      (err) => {
+        this.errorMessages.push(`Error tracking package: ${err.message || err}`);
+        this.isLoadingTracking = false;
+      }
+    );
+  }
+}

--- a/src/app/modules/integrations/integrations-landing/integrations-landing.component.html
+++ b/src/app/modules/integrations/integrations-landing/integrations-landing.component.html
@@ -8,7 +8,7 @@
       <p>Select an integration to manage:</p>
       <mat-nav-list>
         <a mat-list-item *ngFor="let integration of integrations" [routerLink]="integration.path" routerLinkActive="active-link">
-          <mat-icon matListItemIcon>storefront</mat-icon> <!-- Or a more specific icon -->
+          <mat-icon matListItemIcon>{{ integration.icon || 'settings_input_component' }}</mat-icon> <!-- Use integration specific icon or a default -->
           <div matListItemTitle>{{ integration.name }}</div>
           <div matListItemLine>{{ integration.description }}</div>
         </a>

--- a/src/app/modules/integrations/integrations-landing/integrations-landing.component.ts
+++ b/src/app/modules/integrations/integrations-landing/integrations-landing.component.ts
@@ -12,8 +12,14 @@ import { Component } from '@angular/core';
 })
 export class IntegrationsLandingComponent {
   integrations = [
-    { name: 'eBay Integration', path: './ebay', description: 'Synchronize orders from your eBay store.' },
-    { name: 'Shopify Integration', path: './shopify', description: 'Synchronize orders from your Shopify store.' }
+    { name: 'Amazon Marketplace', path: './amazon', description: 'Sync orders, products, and inventory with Amazon.', icon: 'shopping_cart' },
+    { name: 'eBay Marketplace', path: './ebay', description: 'Sync orders, products, and inventory with eBay.', icon: 'storefront' },
+    { name: 'Shopify Store', path: './shopify', description: 'Synchronize orders from your Shopify store.', icon: 'store' },
+    { name: 'QuickBooks Accounting', path: './quickbooks', description: 'Sync invoices, payments, and customers with QuickBooks.', icon: 'assessment' },
+    { name: 'Xero Accounting', path: './xero', description: 'Sync invoices, payments, and contacts with Xero.', icon: 'account_balance_wallet' },
+    { name: 'FedEx Shipping', path: './fedex', description: 'Get rates, create labels, and track FedEx shipments.', icon: 'local_shipping' },
+    { name: 'UPS Shipping', path: './ups', description: 'Get rates, create labels, and track UPS shipments.', icon: 'rv_hookup' }, // rv_hookup is a truck icon
+    { name: 'Shippo Multi-Carrier', path: './shippo', description: 'Manage shipping with multiple carriers via Shippo.', icon: 'dynamic_feed' }
   ];
 
   constructor() { }

--- a/src/app/modules/integrations/integrations.module.ts
+++ b/src/app/modules/integrations/integrations.module.ts
@@ -1,42 +1,54 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Routes } from '@angular/router';
-import { HttpClientModule } from '@angular/common/http'; // Needed for EbayService
+import { HttpClientModule } from '@angular/common/http';
+import { ReactiveFormsModule } from '@angular/forms'; // Import ReactiveFormsModule
 
+import { SharedModule } from '../../shared/shared.module';
+
+import { IntegrationsLandingComponent } from './integrations-landing/integrations-landing.component';
 import { EbayConnectorComponent } from './ebay-connector/ebay-connector.component';
-import { ShopifyConnectorComponent } from './shopify-connector/shopify-connector.component'; // Import new component
-import { IntegrationsLandingComponent } from './integrations-landing/integrations-landing.component'; // Import landing component
-import { SharedModule } from '../../shared/shared.module'; // For UI components like buttons
+import { ShopifyConnectorComponent } from './shopify-connector/shopify-connector.component';
+import { AmazonConnectorComponent } from './amazon-connector/amazon-connector.component';
+import { QuickbooksConnectorComponent } from './quickbooks-connector/quickbooks-connector.component';
+import { XeroConnectorComponent } from './xero-connector/xero-connector.component';
+import { FedexConnectorComponent } from './fedex-connector/fedex-connector.component';
+import { UpsConnectorComponent } from './ups-connector/ups-connector.component';
+import { ShippoConnectorComponent } from './shippo-connector/shippo-connector.component';
 
 const routes: Routes = [
-  {
-    path: '', // Default route for this module, now the landing page
-    component: IntegrationsLandingComponent
-  },
-  {
-    path: 'ebay', // Route for eBay connector
-    component: EbayConnectorComponent
-  },
-  {
-    path: 'shopify', // Route for Shopify connector
-    component: ShopifyConnectorComponent
-  }
+  { path: '', component: IntegrationsLandingComponent },
+  { path: 'ebay', component: EbayConnectorComponent },
+  { path: 'shopify', component: ShopifyConnectorComponent },
+  { path: 'amazon', component: AmazonConnectorComponent },
+  { path: 'quickbooks', component: QuickbooksConnectorComponent },
+  { path: 'xero', component: XeroConnectorComponent },
+  { path: 'fedex', component: FedexConnectorComponent },
+  { path: 'ups', component: UpsConnectorComponent },
+  { path: 'shippo', component: ShippoConnectorComponent },
 ];
 
 @NgModule({
   declarations: [
+    IntegrationsLandingComponent,
     EbayConnectorComponent,
-    ShopifyConnectorComponent, // Declare new component
-    IntegrationsLandingComponent // Declare landing component
+    ShopifyConnectorComponent,
+    AmazonConnectorComponent,
+    QuickbooksConnectorComponent,
+    XeroConnectorComponent,
+    FedexConnectorComponent,
+    UpsConnectorComponent,
+    ShippoConnectorComponent
   ],
   imports: [
     CommonModule,
     RouterModule.forChild(routes),
-    HttpClientModule, // Make sure HttpClientModule is available for EbayService
-    SharedModule      // Import SharedModule for Material components or other UI elements
+    HttpClientModule, // For services that use HttpClient
+    ReactiveFormsModule, // Add for form functionalities in new components
+    SharedModule      // For Material components and other shared UI elements
   ],
   providers: [
-    // EbayService and ItemService are already providedIn: 'root'
+    // Services are typically providedIn: 'root'
   ]
 })
 export class IntegrationsModule { }

--- a/src/app/modules/integrations/quickbooks-connector/quickbooks-connector.component.html
+++ b/src/app/modules/integrations/quickbooks-connector/quickbooks-connector.component.html
@@ -1,0 +1,61 @@
+<div class="connector-container">
+  <h2>QuickBooks Integration</h2>
+
+  <div class="sync-section">
+    <button (click)="syncAllData()" [disabled]="isLoading" mat-raised-button color="primary" class="mr-2">
+      <mat-icon>sync</mat-icon>
+      {{ isLoading ? 'Syncing All Data...' : 'Sync Data to QuickBooks' }}
+    </button>
+    <button (click)="fetchInvoicesFromQuickBooks()" [disabled]="isLoading" mat-raised-button>
+      <mat-icon>cloud_download</mat-icon>
+      {{ isLoading ? 'Fetching Invoices...' : 'Fetch Invoices from QuickBooks' }}
+    </button>
+  </div>
+
+  <mat-progress-bar mode="indeterminate" *ngIf="isLoading"></mat-progress-bar>
+
+  <div class="sync-info" *ngIf="lastSyncTime && !isLoading">
+    <p>Last sync/fetch attempt: {{ lastSyncTime | date:'medium' }}</p>
+  </div>
+
+  <div *ngIf="successMessages.length > 0 && !isLoading" class="success-messages">
+    <h4>Sync/Fetch Report:</h4>
+    <ul>
+      <li *ngFor="let msg of successMessages">{{ msg }}</li>
+    </ul>
+  </div>
+
+  <div *ngIf="errorMessages.length > 0 && !isLoading" class="error-messages">
+    <h4>Errors:</h4>
+    <ul>
+      <li *ngFor="let msg of errorMessages">{{ msg }}</li>
+    </ul>
+  </div>
+
+  <div *ngIf="quickbooksInvoices.length > 0 && !isLoading" class="mt-4">
+    <h3>Fetched QuickBooks Invoices (Mock Data)</h3>
+    <ul class="list-group">
+      <li *ngFor="let invoice of quickbooksInvoices" class="list-group-item">
+        ID: {{invoice.Id}}, Doc #: {{invoice.DocNumber || 'N/A'}}, Customer: {{invoice.CustomerRef?.name || invoice.CustomerRef?.value}}, Amount: {{invoice.TotalAmt | currency}}
+        <div *ngIf="invoice.Line && invoice.Line.length > 0">
+          Items:
+          <ul>
+            <li *ngFor="let item of invoice.Line">
+              {{item.SalesItemLineDetail?.ItemRef?.name || 'Unknown Item'}}: {{item.Amount | currency}}
+            </li>
+          </ul>
+        </div>
+      </li>
+    </ul>
+  </div>
+
+  <div class="integration-details mt-4">
+    <h3>Configuration (Placeholder)</h3>
+    <p>
+      QuickBooks integration allows syncing invoices, payments, and customer data between your application and QuickBooks Online.
+    </p>
+    <p>
+      <em>Note: This integration currently uses mock data and simulates API calls. Full API connectivity is pending.</em>
+    </p>
+  </div>
+</div>

--- a/src/app/modules/integrations/quickbooks-connector/quickbooks-connector.component.scss
+++ b/src/app/modules/integrations/quickbooks-connector/quickbooks-connector.component.scss
@@ -1,0 +1,102 @@
+.connector-container {
+  padding: 20px;
+  max-width: 900px;
+  margin: auto;
+}
+
+.sync-section {
+  margin-bottom: 20px;
+  display: flex;
+  gap: 10px; /* Space between buttons */
+}
+
+.sync-section button mat-icon {
+  margin-right: 8px;
+}
+
+mat-progress-bar {
+  margin-bottom: 20px;
+}
+
+.sync-info {
+  margin-top: 15px;
+  padding: 10px;
+  background-color: #f0f0f0;
+  border-radius: 4px;
+  border: 1px solid #e0e0e0;
+  font-size: 0.9em;
+}
+
+.success-messages, .error-messages {
+  margin-top: 15px;
+  padding: 10px;
+  border-radius: 4px;
+}
+
+.success-messages {
+  background-color: #e8f5e9; /* Light green */
+  border: 1px solid #a5d6a7;
+  color: #2e7d32; /* Darker green */
+}
+
+.error-messages {
+  background-color: #ffebee; /* Light red */
+  border: 1px solid #ef9a9a;
+  color: #c62828; /* Darker red */
+}
+
+.success-messages h4, .error-messages h4 {
+  margin-top: 0;
+}
+
+.success-messages ul, .error-messages ul {
+  padding-left: 20px;
+  margin-bottom: 0;
+}
+
+.integration-details {
+  margin-top: 20px;
+  padding: 15px;
+  background-color: #e3f2fd; /* Light blue */
+  border: 1px solid #90caf9;
+  border-radius: 4px;
+}
+
+.integration-details h3 {
+  margin-top: 0;
+  color: #0d47a1; /* Dark blue */
+}
+
+/* Basic styling for list groups if bootstrap is not fully available */
+.list-group {
+  padding-left: 0;
+  margin-bottom: 20px;
+}
+
+.list-group-item {
+  position: relative;
+  display: block;
+  padding: 0.75rem 1.25rem;
+  background-color: #fff;
+  border: 1px solid rgba(0,0,0,.125);
+}
+
+.list-group-item:first-child {
+  border-top-left-radius: .25rem;
+  border-top-right-radius: .25rem;
+}
+
+.list-group-item:last-child {
+  border-bottom-right-radius: .25rem;
+  border-bottom-left-radius: .25rem;
+  margin-bottom: 0;
+  border-bottom-width: 1px;
+}
+
+.list-group-item + .list-group-item {
+  border-top-width: 0;
+}
+
+.mr-2 {
+  margin-right: 0.5rem; /* For spacing between buttons if not using flex gap effectively */
+}

--- a/src/app/modules/integrations/quickbooks-connector/quickbooks-connector.component.spec.ts
+++ b/src/app/modules/integrations/quickbooks-connector/quickbooks-connector.component.spec.ts
@@ -1,0 +1,160 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+
+import { QuickbooksConnectorComponent } from './quickbooks-connector.component';
+import { QuickBooksService } from '../../services/quickbooks.service';
+
+// Material Modules
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list'; // For displaying fetched invoices
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+class MockQuickBooksService {
+  syncInvoices = jasmine.createSpy('syncInvoices').and.returnValue(of(true));
+  syncPayments = jasmine.createSpy('syncPayments').and.returnValue(of(true));
+  syncCustomers = jasmine.createSpy('syncCustomers').and.returnValue(of(true));
+  fetchQuickBooksInvoices = jasmine.createSpy('fetchQuickBooksInvoices').and.returnValue(of([]));
+}
+
+describe('QuickbooksConnectorComponent', () => {
+  let component: QuickbooksConnectorComponent;
+  let fixture: ComponentFixture<QuickbooksConnectorComponent>;
+  let quickbooksService: MockQuickBooksService;
+
+  const mockRawInvoice = { Id: "1", DocNumber: "INV001", TotalAmt: 100, CustomerRef: { value: "cust1", name: "Customer 1" }, Line: [], SyncToken: "0" };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [QuickbooksConnectorComponent],
+      imports: [
+        ReactiveFormsModule, // Though this component doesn't have forms, its template might use form directives from Material
+        NoopAnimationsModule,
+        MatCardModule,
+        MatButtonModule,
+        MatProgressBarModule,
+        MatIconModule,
+        MatListModule
+      ],
+      providers: [
+        { provide: QuickBooksService, useClass: MockQuickBooksService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(QuickbooksConnectorComponent);
+    component = fixture.componentInstance;
+    quickbooksService = TestBed.inject(QuickBooksService) as unknown as MockQuickBooksService;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('syncAllData', () => {
+    it('should set isLoading to true and reset messages', () => {
+      component.syncAllData();
+      expect(component.isLoading).toBeTrue();
+      expect(component.errorMessages.length).toBe(0);
+      expect(component.successMessages.length).toBe(0);
+    });
+
+    it('should call all sync methods on QuickBooksService', fakeAsync(() => {
+      component.syncAllData();
+      tick(); // allow observables to resolve for all three calls
+
+      expect(quickbooksService.syncInvoices).toHaveBeenCalled();
+      expect(quickbooksService.syncPayments).toHaveBeenCalled();
+      expect(quickbooksService.syncCustomers).toHaveBeenCalled();
+
+      expect(component.successMessages.length).toBe(3); // Expect 3 success messages
+      expect(component.isLoading).toBeFalse();
+      expect(component.lastSyncTime).not.toBeNull();
+    }));
+
+    it('should handle errors from syncInvoices', fakeAsync(() => {
+      quickbooksService.syncInvoices.and.returnValue(throwError(() => new Error('Invoice sync failed')));
+      component.syncAllData();
+      tick();
+
+      expect(component.errorMessages).toContain('Error syncing invoices: Invoice sync failed');
+      // Depending on implementation, other calls might still succeed or not run.
+      // Current component runs them in parallel, so others would still complete.
+      expect(quickbooksService.syncPayments).toHaveBeenCalled();
+      expect(quickbooksService.syncCustomers).toHaveBeenCalled();
+      expect(component.isLoading).toBeFalse();
+    }));
+
+     it('should handle false return from syncPayments (simulating a specific failure type)', fakeAsync(() => {
+      quickbooksService.syncPayments.and.returnValue(of(false));
+      component.syncAllData();
+      tick();
+
+      expect(component.errorMessages).toContain('Failed to sync payments (mock).');
+      expect(component.isLoading).toBeFalse();
+    }));
+  });
+
+  describe('fetchInvoicesFromQuickBooks', () => {
+    it('should set isLoading and reset messages/data', () => {
+      component.fetchInvoicesFromQuickBooks();
+      expect(component.isLoading).toBeTrue();
+      expect(component.errorMessages.length).toBe(0);
+      expect(component.successMessages.length).toBe(0);
+      expect(component.quickbooksInvoices.length).toBe(0);
+    });
+
+    it('should call fetchQuickBooksInvoices and populate quickbooksInvoices', fakeAsync(() => {
+      quickbooksService.fetchQuickBooksInvoices.and.returnValue(of([mockRawInvoice]));
+      component.fetchInvoicesFromQuickBooks();
+      tick();
+
+      expect(quickbooksService.fetchQuickBooksInvoices).toHaveBeenCalled();
+      expect(component.quickbooksInvoices.length).toBe(1);
+      expect(component.quickbooksInvoices[0].Id).toBe("1");
+      expect(component.successMessages).toContain('Successfully fetched 1 invoices from QuickBooks (mock).');
+      expect(component.isLoading).toBeFalse();
+      expect(component.lastSyncTime).not.toBeNull();
+    }));
+
+    it('should handle empty array from fetchQuickBooksInvoices', fakeAsync(() => {
+      quickbooksService.fetchQuickBooksInvoices.and.returnValue(of([]));
+      component.fetchInvoicesFromQuickBooks();
+      tick();
+
+      expect(component.quickbooksInvoices.length).toBe(0);
+      expect(component.successMessages).toContain('No invoices found in QuickBooks (mock) or an error occurred during fetch.');
+      expect(component.isLoading).toBeFalse();
+    }));
+
+    it('should handle errors from fetchQuickBooksInvoices', fakeAsync(() => {
+      quickbooksService.fetchQuickBooksInvoices.and.returnValue(throwError(() => new Error('Fetch QB invoices failed')));
+      component.fetchInvoicesFromQuickBooks();
+      tick();
+
+      expect(component.errorMessages).toContain('Error fetching invoices from QuickBooks: Fetch QB invoices failed');
+      expect(component.isLoading).toBeFalse();
+    }));
+  });
+
+  describe('checkCompletion', () => {
+    it('should set isLoading to false and update lastSyncTime when all operations complete', () => {
+      component.isLoading = true;
+      component.lastSyncTime = null;
+      (component as any).checkCompletion(3, 3); // Access private method
+      expect(component.isLoading).toBeFalse();
+      expect(component.lastSyncTime).not.toBeNull();
+    });
+
+    it('should not change isLoading if not all operations are complete', () => {
+      component.isLoading = true;
+      component.lastSyncTime = null;
+      (component as any).checkCompletion(2, 3);
+      expect(component.isLoading).toBeTrue();
+      expect(component.lastSyncTime).toBeNull();
+    });
+  });
+});

--- a/src/app/modules/integrations/quickbooks-connector/quickbooks-connector.component.ts
+++ b/src/app/modules/integrations/quickbooks-connector/quickbooks-connector.component.ts
@@ -1,0 +1,111 @@
+import { Component, OnInit } from '@angular/core';
+import { QuickBooksService } from '../../services/quickbooks.service'; // Corrected path assuming service location
+
+@Component({
+  selector: 'app-quickbooks-connector',
+  templateUrl: './quickbooks-connector.component.html',
+  styleUrls: ['./quickbooks-connector.component.scss']
+})
+export class QuickbooksConnectorComponent implements OnInit {
+  isLoading: boolean = false;
+  lastSyncTime: Date | null = null;
+  errorMessages: string[] = [];
+  successMessages: string[] = [];
+
+  // Example: Hold fetched invoices
+  quickbooksInvoices: any[] = [];
+
+  constructor(private quickbooksService: QuickBooksService) { }
+
+  ngOnInit(): void {
+    // Optionally, fetch some data on init if needed
+    // this.fetchInvoices();
+  }
+
+  syncAllData(): void {
+    this.isLoading = true;
+    this.errorMessages = [];
+    this.successMessages = [];
+    let operationsCompleted = 0;
+    const totalOperations = 3; // Invoices, Payments, Customers
+
+    // For simplicity, these are mock data. In a real app, you'd get this from your application's state/services.
+    const mockAppInvoices = [{ id: 'appInv1', amount: 100, customerId: 'cust123' }];
+    const mockAppPayments = [{ id: 'appPay1', amount: 100, invoiceId: 'appInv1' }];
+    const mockAppCustomers = [{ id: 'cust123', name: 'Test Customer App' }];
+
+    this.quickbooksService.syncInvoices(mockAppInvoices).subscribe(
+      success => {
+        if (success) this.successMessages.push('Invoices synced successfully (mock).');
+        else this.errorMessages.push('Failed to sync invoices (mock).');
+        operationsCompleted++;
+        this.checkCompletion(operationsCompleted, totalOperations);
+      },
+      err => {
+        this.errorMessages.push(`Error syncing invoices: ${err.message || err}`);
+        operationsCompleted++;
+        this.checkCompletion(operationsCompleted, totalOperations);
+      }
+    );
+
+    this.quickbooksService.syncPayments(mockAppPayments).subscribe(
+      success => {
+        if (success) this.successMessages.push('Payments synced successfully (mock).');
+        else this.errorMessages.push('Failed to sync payments (mock).');
+        operationsCompleted++;
+        this.checkCompletion(operationsCompleted, totalOperations);
+      },
+      err => {
+        this.errorMessages.push(`Error syncing payments: ${err.message || err}`);
+        operationsCompleted++;
+        this.checkCompletion(operationsCompleted, totalOperations);
+      }
+    );
+
+    this.quickbooksService.syncCustomers(mockAppCustomers).subscribe(
+      success => {
+        if (success) this.successMessages.push('Customers synced successfully (mock).');
+        else this.errorMessages.push('Failed to sync customers (mock).');
+        operationsCompleted++;
+        this.checkCompletion(operationsCompleted, totalOperations);
+      },
+      err => {
+        this.errorMessages.push(`Error syncing customers: ${err.message || err}`);
+        operationsCompleted++;
+        this.checkCompletion(operationsCompleted, totalOperations);
+      }
+    );
+  }
+
+  fetchInvoicesFromQuickBooks(): void {
+    this.isLoading = true;
+    this.errorMessages = [];
+    this.successMessages = [];
+    this.quickbooksInvoices = [];
+
+    this.quickbooksService.fetchQuickBooksInvoices().subscribe(
+      invoices => {
+        this.quickbooksInvoices = invoices;
+        if (invoices.length > 0) {
+          this.successMessages.push(`Successfully fetched ${invoices.length} invoices from QuickBooks (mock).`);
+        } else {
+          this.successMessages.push('No invoices found in QuickBooks (mock) or an error occurred during fetch.');
+        }
+        this.isLoading = false;
+        this.lastSyncTime = new Date();
+      },
+      err => {
+        this.errorMessages.push(`Error fetching invoices from QuickBooks: ${err.message || err}`);
+        this.isLoading = false;
+        this.lastSyncTime = new Date();
+      }
+    );
+  }
+
+  private checkCompletion(completed: number, total: number): void {
+    if (completed === total) {
+      this.isLoading = false;
+      this.lastSyncTime = new Date();
+    }
+  }
+}

--- a/src/app/modules/integrations/shippo-connector/shippo-connector.component.html
+++ b/src/app/modules/integrations/shippo-connector/shippo-connector.component.html
@@ -1,0 +1,177 @@
+<div class="connector-container">
+  <h2>Shippo Multi-Carrier Shipping</h2>
+
+  <!-- Error Messages -->
+  <div *ngIf="errorMessages.length > 0" class="error-messages alert alert-danger">
+    <h4>Errors:</h4>
+    <ul>
+      <li *ngFor="let msg of errorMessages">{{ msg }}</li>
+    </ul>
+  </div>
+
+  <!-- Shipment Details & Rates Section -->
+  <mat-card class="mb-3">
+    <mat-card-header>
+      <mat-card-title>1. Define Shipment & Get Rates</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="row">
+        <!-- Address From -->
+        <div class="col-md-6" [formGroup]="addressFromForm">
+          <h5>Address From:</h5>
+          <mat-form-field class="w-100"><input matInput placeholder="Name" formControlName="name"></mat-form-field>
+          <mat-form-field class="w-100"><input matInput placeholder="Street 1" formControlName="street1"></mat-form-field>
+          <mat-form-field class="w-100"><input matInput placeholder="City" formControlName="city"></mat-form-field>
+          <mat-form-field class="w-100"><input matInput placeholder="State (e.g., CA)" formControlName="state"></mat-form-field>
+          <mat-form-field class="w-100"><input matInput placeholder="ZIP Code" formControlName="zip"></mat-form-field>
+          <mat-form-field class="w-100"><input matInput placeholder="Country (e.g., US)" formControlName="country"></mat-form-field>
+          <mat-form-field class="w-100"><input matInput placeholder="Phone" formControlName="phone"></mat-form-field>
+        </div>
+        <!-- Address To -->
+        <div class="col-md-6" [formGroup]="addressToForm">
+          <h5>Address To:</h5>
+          <mat-form-field class="w-100"><input matInput placeholder="Name" formControlName="name"></mat-form-field>
+          <mat-form-field class="w-100"><input matInput placeholder="Street 1" formControlName="street1"></mat-form-field>
+          <mat-form-field class="w-100"><input matInput placeholder="City" formControlName="city"></mat-form-field>
+          <mat-form-field class="w-100"><input matInput placeholder="State (e.g., CA)" formControlName="state"></mat-form-field>
+          <mat-form-field class="w-100"><input matInput placeholder="ZIP Code" formControlName="zip"></mat-form-field>
+          <mat-form-field class="w-100"><input matInput placeholder="Country (e.g., US)" formControlName="country"></mat-form-field>
+          <mat-form-field class="w-100"><input matInput placeholder="Phone" formControlName="phone"></mat-form-field>
+        </div>
+      </div>
+      <hr>
+      <!-- Parcel Details -->
+      <div [formGroup]="parcelForm">
+        <h5>Parcel Details:</h5>
+        <div class="row">
+          <div class="col-md-3"><mat-form-field class="w-100"><input matInput type="text" placeholder="Length" formControlName="length"></mat-form-field></div>
+          <div class="col-md-3"><mat-form-field class="w-100"><input matInput type="text" placeholder="Width" formControlName="width"></mat-form-field></div>
+          <div class="col-md-3"><mat-form-field class="w-100"><input matInput type="text" placeholder="Height" formControlName="height"></mat-form-field></div>
+          <div class="col-md-3">
+            <mat-form-field class="w-100">
+              <mat-label>Distance Unit</mat-label>
+              <mat-select formControlName="distance_unit">
+                <mat-option value="in">in</mat-option>
+                <mat-option value="cm">cm</mat-option>
+              </mat-select>
+            </mat-form-field>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-6"><mat-form-field class="w-100"><input matInput type="text" placeholder="Weight" formControlName="weight"></mat-form-field></div>
+          <div class="col-md-6">
+            <mat-form-field class="w-100">
+              <mat-label>Mass Unit</mat-label>
+              <mat-select formControlName="mass_unit">
+                <mat-option value="lb">lb</mat-option>
+                <mat-option value="oz">oz</mat-option>
+                <mat-option value="kg">kg</mat-option>
+                <mat-option value="g">g</mat-option>
+              </mat-select>
+            </mat-form-field>
+          </div>
+        </div>
+      </div>
+      <button mat-raised-button color="primary" (click)="getShipmentRates()" [disabled]="isLoadingRates || addressFromForm.invalid || addressToForm.invalid || parcelForm.invalid">
+        <mat-icon>calculate</mat-icon>
+        {{ isLoadingRates ? 'Calculating...' : 'Get Shippo Rates' }}
+      </button>
+    </mat-card-content>
+    <mat-card-actions *ngIf="isLoadingRates">
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+    </mat-card-actions>
+    <div *ngIf="rates.length > 0 && !isLoadingRates" class="mt-3 results-section">
+      <h4>Available Rates (Mock):</h4>
+      <mat-radio-group [(ngModel)]="selectedRateId" (ngModelChange)="selectRate($event)">
+        <ul class="list-group">
+          <li *ngFor="let rate of rates" class="list-group-item d-flex align-items-center">
+            <mat-radio-button [value]="rate.object_id" class="mr-2"></mat-radio-button>
+            <img *ngIf="rate.provider_image_75" [src]="rate.provider_image_75" [alt]="rate.provider" class="carrier-logo mr-2">
+            {{ rate.provider }} {{ rate.servicelevel.name }}: {{ rate.amount | currency:rate.currency }}
+            <span *ngIf="rate.estimated_days"> (Est. {{ rate.estimated_days }} days)</span>
+          </li>
+        </ul>
+      </mat-radio-group>
+    </div>
+  </mat-card>
+
+  <!-- Create Label Section -->
+  <mat-card class="mb-3" *ngIf="rates.length > 0">
+    <mat-card-header>
+      <mat-card-title>2. Create Shipping Label</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <p *ngIf="!selectedRateId" class="text-muted">Select a rate above to create a label.</p>
+      <button mat-raised-button color="accent" (click)="createLabel()" [disabled]="isLoadingLabel || !selectedRateId">
+        <mat-icon>receipt_long</mat-icon>
+        {{ isLoadingLabel ? 'Creating...' : 'Create Shippo Label' }}
+      </button>
+    </mat-card-content>
+    <mat-card-actions *ngIf="isLoadingLabel">
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+    </mat-card-actions>
+    <div *ngIf="transactionInfo && !isLoadingLabel" class="mt-3 results-section">
+      <h4>Label Transaction (Mock):</h4>
+      <p>Status: <strong>{{ transactionInfo.status }}</strong></p>
+      <p>Tracking Number: <strong>{{ transactionInfo.tracking_number }}</strong></p>
+      <p><a [href]="transactionInfo.label_url" target="_blank" mat-stroked-button>Download Label (Mock URL)</a></p>
+      <p *ngIf="transactionInfo.tracking_url_provider"><a [href]="transactionInfo.tracking_url_provider" target="_blank" mat-stroked-button>Track via Provider (Mock URL)</a></p>
+      <ul *ngIf="transactionInfo.messages && transactionInfo.messages.length > 0">
+        <li *ngFor="let message of transactionInfo.messages">{{message.text}}</li>
+      </ul>
+    </div>
+  </mat-card>
+
+  <!-- Track Package Section -->
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Track Package via Shippo</mat-card-title>
+    </mat-card-header>
+    <mat-card-content [formGroup]="trackingForm">
+      <div class="row">
+        <div class="col-md-6">
+          <mat-form-field class="w-100">
+            <mat-label>Carrier Token</mat-label>
+            <mat-select formControlName="carrierToken">
+              <mat-option *ngFor="let carrier of shippoCarriers" [value]="carrier.token">
+                {{carrier.name}} ({{carrier.token}})
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+        <div class="col-md-6">
+          <mat-form-field class="w-100">
+            <mat-label>Tracking Number</mat-label>
+            <input matInput formControlName="trackingNumber">
+          </mat-form-field>
+        </div>
+      </div>
+      <button mat-raised-button color="warn" (click)="trackPackage()" [disabled]="isLoadingTracking || trackingForm.invalid">
+        <mat-icon>pin_drop</mat-icon>
+        {{ isLoadingTracking ? 'Tracking...' : 'Track via Shippo' }}
+      </button>
+    </mat-card-content>
+    <mat-card-actions *ngIf="isLoadingTracking">
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+    </mat-card-actions>
+    <div *ngIf="trackingInfo && !isLoadingTracking" class="mt-3 results-section">
+      <h4>Tracking Information for {{ trackingInfo.tracking_number }} (Mock):</h4>
+      <p>Carrier: {{ trackingInfo.carrier }}</p>
+      <p>Status: {{ getTrackingStatus(trackingInfo) }}</p>
+      <p *ngIf="trackingInfo.eta">Estimated Delivery: {{ trackingInfo.eta | date:'medium' }}</p>
+      <div *ngIf="trackingInfo.tracking_history && trackingInfo.tracking_history.length > 0">
+        <h5>History:</h5>
+        <ul>
+          <li *ngFor="let event of trackingInfo.tracking_history">
+            {{event.status_details}} on {{event.status_date | date:'medium'}}
+            <span *ngIf="event.location?.city"> at {{event.location.city}}, {{event.location.state}}</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </mat-card>
+
+  <div class="integration-details mt-4">
+    <p><em>Note: This Shippo integration uses mock data. Full API connectivity is pending. Address validation and customs declarations for international shipping are not yet implemented in this mock.</em></p>
+  </div>
+</div>

--- a/src/app/modules/integrations/shippo-connector/shippo-connector.component.scss
+++ b/src/app/modules/integrations/shippo-connector/shippo-connector.component.scss
@@ -1,0 +1,139 @@
+// Reusing styles similar to FedEx/UPS connectors for general layout.
+// Shippo specific styling can be added or refined here.
+
+.connector-container {
+  padding: 20px;
+  max-width: 950px; // Slightly wider for more complex forms
+  margin: auto;
+}
+
+mat-card {
+  margin-bottom: 20px;
+}
+
+.w-100 {
+  width: 100%;
+}
+.mr-2 { margin-right: .5rem; }
+.mb-3 { margin-bottom: 1rem !important; }
+.mt-3 { margin-top: 1rem !important; }
+.mt-4 { margin-top: 1.5rem !important; }
+
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -15px; /* Gutters */
+  margin-left: -15px;
+}
+
+.col-md-3, .col-md-6 {
+  position: relative;
+  width: 100%;
+  padding-right: 15px; /* Gutters */
+  padding-left: 15px;
+}
+
+.col-md-3 {
+  flex: 0 0 25%;
+  max-width: 25%;
+}
+.col-md-6 {
+  flex: 0 0 50%;
+  max-width: 50%;
+}
+
+button mat-icon {
+  margin-right: 8px;
+}
+
+mat-progress-bar {
+  margin-top: 10px;
+}
+
+.results-section {
+  padding: 15px;
+  background-color: #f8f9fa;
+  border-radius: 4px;
+  border: 1px solid #e9ecef;
+}
+
+.results-section h4, .results-section h5 {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.error-messages {
+  margin-bottom: 15px;
+}
+.error-messages h4 { margin-top: 0; }
+.error-messages ul { padding-left: 20px; margin-bottom: 0; }
+
+
+.integration-details {
+  padding: 15px;
+  background-color: #f0f4f8; // Light blue-grey, neutral for multi-carrier
+  border: 1px solid #d6e0ea;
+  border-radius: 4px;
+  font-size: 0.9em;
+  color: #334e68;
+}
+
+/* Basic alert styling */
+.alert {
+  position: relative;
+  padding: .75rem 1.25rem;
+  margin-bottom: 1rem;
+  border: 1px solid transparent;
+  border-radius: .25rem;
+}
+.alert-danger {
+  color: #721c24;
+  background-color: #f8d7da;
+  border-color: #f5c6cb;
+}
+
+/* Basic list group styling for rates */
+.list-group {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0;
+  margin-bottom: 0;
+}
+.list-group-item {
+  position: relative;
+  display: block;
+  padding: .75rem 1.25rem;
+  background-color: #fff;
+  border: 1px solid rgba(0,0,0,.125);
+  // For aligning radio button and image
+  display: flex;
+  align-items: center;
+}
+.list-group-item:first-child { border-top-left-radius: inherit; border-top-right-radius: inherit; }
+.list-group-item:last-child { border-bottom-right-radius: inherit; border-bottom-left-radius: inherit; margin-bottom: -1px; }
+.list-group-item + .list-group-item { border-top-width: 0; }
+
+.carrier-logo {
+  height: 20px; // Adjust as needed
+  width: auto;
+  margin-right: 8px;
+}
+
+// Ensure form fields don't get too squeezed in flex rows without explicit sizing
+mat-form-field {
+  min-width: 120px; // Adjust as needed
+}
+
+// Styles for mat-radio-group within list items
+mat-radio-group .list-group-item {
+  cursor: pointer; // Make it clear it's clickable
+}
+mat-radio-group .list-group-item:hover {
+  background-color: #f0f0f0;
+}
+mat-radio-button {
+  margin-right: 10px;
+}
+.d-flex { display: flex !important; }
+.align-items-center { align-items: center !important; }

--- a/src/app/modules/integrations/shippo-connector/shippo-connector.component.spec.ts
+++ b/src/app/modules/integrations/shippo-connector/shippo-connector.component.spec.ts
@@ -1,0 +1,197 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+
+import { ShippoConnectorComponent } from './shippo-connector.component';
+import { ShippoService } from '../../services/shippo.service';
+
+// Material Modules
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { MatRadioModule } from '@angular/material/radio'; // For rate selection
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+// Mock ShippoService
+class MockShippoService {
+  createShipmentAndGetRates = jasmine.createSpy('createShipmentAndGetRates').and.returnValue(of([]));
+  createShippingLabel = jasmine.createSpy('createShippingLabel').and.returnValue(of(null));
+  trackShipment = jasmine.createSpy('trackShipment').and.returnValue(of(null));
+}
+
+describe('ShippoConnectorComponent', () => {
+  let component: ShippoConnectorComponent;
+  let fixture: ComponentFixture<ShippoConnectorComponent>;
+  let shippoService: MockShippoService;
+
+  const mockRates = [{ object_id: 'rate1', amount: '10', currency: 'USD', provider: 'USPS', servicelevel: { token: 'usps_priority', name: 'Priority' } }];
+  const mockTransaction = { object_id: 'txn1', status: 'SUCCESS', tracking_number: 'track123', label_url: 'label.pdf', tracking_url_provider: 'track.com' };
+  const mockTrackInfo = { carrier: 'usps', tracking_number: 'track123', tracking_status: { status: 'DELIVERED', status_details: 'Delivered', status_date: new Date().toISOString() } };
+
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ShippoConnectorComponent],
+      imports: [
+        ReactiveFormsModule,
+        NoopAnimationsModule,
+        MatCardModule, MatFormFieldModule, MatInputModule, MatSelectModule,
+        MatButtonModule, MatProgressBarModule, MatIconModule, MatListModule, MatRadioModule
+      ],
+      providers: [
+        { provide: ShippoService, useClass: MockShippoService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ShippoConnectorComponent);
+    component = fixture.componentInstance;
+    shippoService = TestBed.inject(ShippoService) as unknown as MockShippoService;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('getShipmentRates', () => {
+    it('should not call service if forms are invalid', () => {
+      component.addressFromForm.controls['name'].setValue(''); // Invalid
+      component.getShipmentRates();
+      expect(shippoService.createShipmentAndGetRates).not.toHaveBeenCalled();
+      expect(component.errorMessages).toContain('Please fill all required address and parcel fields.');
+    });
+
+    it('should call service and populate rates if forms are valid', fakeAsync(() => {
+      shippoService.createShipmentAndGetRates.and.returnValue(of(mockRates as any[]));
+      // Forms are valid by default in this setup
+      component.getShipmentRates();
+      tick();
+
+      expect(shippoService.createShipmentAndGetRates).toHaveBeenCalled();
+      expect(component.rates.length).toBe(1);
+      expect(component.rates[0].provider).toBe('USPS');
+      expect(component.isLoadingRates).toBeFalse();
+    }));
+
+    it('should handle empty rates response', fakeAsync(() => {
+      shippoService.createShipmentAndGetRates.and.returnValue(of([]));
+      component.getShipmentRates();
+      tick();
+      expect(component.rates.length).toBe(0);
+      expect(component.errorMessages).toContain('No rates returned from Shippo (mock).');
+    }));
+
+
+    it('should handle error from service', fakeAsync(() => {
+      shippoService.createShipmentAndGetRates.and.returnValue(throwError(() => new Error('Shippo API Error')));
+      component.getShipmentRates();
+      tick();
+      expect(component.errorMessages).toContain('Error fetching rates: Shippo API Error');
+      expect(component.isLoadingRates).toBeFalse();
+    }));
+  });
+
+  describe('selectRate', () => {
+    it('should set selectedRateId and clear transactionInfo', () => {
+      component.transactionInfo = mockTransaction as any; // Pre-set some info
+      component.selectRate('new_rate_id');
+      expect(component.selectedRateId).toBe('new_rate_id');
+      expect(component.transactionInfo).toBeNull();
+    });
+  });
+
+  describe('createLabel', () => {
+    it('should not call service if no rate is selected', () => {
+      component.selectedRateId = null;
+      component.createLabel();
+      expect(shippoService.createShippingLabel).not.toHaveBeenCalled();
+      expect(component.errorMessages).toContain('Please select a shipping rate first.');
+    });
+
+    it('should call service and set transactionInfo if rate is selected', fakeAsync(() => {
+      shippoService.createShippingLabel.and.returnValue(of(mockTransaction as any));
+      component.selectedRateId = 'rate1';
+      component.createLabel();
+      tick();
+
+      expect(shippoService.createShippingLabel).toHaveBeenCalledWith({ rate: 'rate1', label_file_type: 'PNG' });
+      expect(component.transactionInfo).toEqual(mockTransaction as any);
+      expect(component.isLoadingLabel).toBeFalse();
+    }));
+
+    it('should handle non-SUCCESS status from createShippingLabel', fakeAsync(() => {
+      const errorTransaction = { ...mockTransaction, status: 'ERROR' };
+      shippoService.createShippingLabel.and.returnValue(of(errorTransaction as any));
+      component.selectedRateId = 'rate1';
+      component.createLabel();
+      tick();
+      expect(component.errorMessages).toContain('Label creation failed or status is not SUCCESS (mock). Status: ERROR');
+      expect(component.isLoadingLabel).toBeFalse();
+    }));
+
+    it('should handle error from service', fakeAsync(() => {
+      shippoService.createShippingLabel.and.returnValue(throwError(() => new Error('Shippo Label Error')));
+      component.selectedRateId = 'rate1';
+      component.createLabel();
+      tick();
+      expect(component.errorMessages).toContain('Error creating label: Shippo Label Error');
+      expect(component.isLoadingLabel).toBeFalse();
+    }));
+  });
+
+  describe('trackPackage', () => {
+    it('should not call service if trackingForm is invalid', () => {
+      component.trackingForm.controls['trackingNumber'].setValue(''); // Invalid
+      component.trackPackage();
+      expect(shippoService.trackShipment).not.toHaveBeenCalled();
+      expect(component.errorMessages).toContain('Please select a carrier and enter a tracking number.');
+    });
+
+    it('should call service and set trackingInfo', fakeAsync(() => {
+      shippoService.trackShipment.and.returnValue(of(mockTrackInfo as any));
+      component.trackingForm.patchValue({ carrierToken: 'usps', trackingNumber: 'track123' });
+      component.trackPackage();
+      tick();
+
+      expect(shippoService.trackShipment).toHaveBeenCalledWith({ carrier: 'usps', tracking_number: 'track123' });
+      expect(component.trackingInfo).toEqual(mockTrackInfo as any);
+      expect(component.isLoadingTracking).toBeFalse();
+    }));
+
+     it('should handle null response from trackShipment', fakeAsync(() => {
+      shippoService.trackShipment.and.returnValue(of(null));
+      component.trackingForm.patchValue({ carrierToken: 'usps', trackingNumber: 'track123' });
+      component.trackPackage();
+      tick();
+      expect(component.trackingInfo).toBeNull();
+      expect(component.errorMessages).toContain('No tracking data returned from Shippo (mock).');
+    }));
+
+    it('should handle error from service', fakeAsync(() => {
+      shippoService.trackShipment.and.returnValue(throwError(() => new Error('Shippo Track Error')));
+      component.trackingForm.patchValue({ carrierToken: 'usps', trackingNumber: 'track123' });
+      component.trackPackage();
+      tick();
+      expect(component.errorMessages).toContain('Error tracking package: Shippo Track Error');
+      expect(component.isLoadingTracking).toBeFalse();
+    }));
+  });
+
+  describe('getTrackingStatus', () => {
+    it('should format tracking status correctly', () => {
+      const statusString = component.getTrackingStatus(mockTrackInfo as any);
+      expect(statusString).toContain('Delivered');
+      expect(statusString).toContain(new Date(mockTrackInfo.tracking_status.status_date).toLocaleString());
+    });
+
+    it('should return N/A if no track info or status', () => {
+      expect(component.getTrackingStatus(null)).toBe('N/A');
+      expect(component.getTrackingStatus({ tracking_status: undefined } as any)).toBe('N/A');
+    });
+  });
+});

--- a/src/app/modules/integrations/shippo-connector/shippo-connector.component.ts
+++ b/src/app/modules/integrations/shippo-connector/shippo-connector.component.ts
@@ -1,0 +1,171 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ShippoService } from '../../services/shippo.service'; // Assuming service in modules/services
+
+// Re-declare or import interfaces (ensure they match service or are more specific to component needs)
+interface ShippoAddress { name: string; street1: string; city: string; state: string; zip: string; country: string; phone?: string; email?: string; }
+interface ShippoParcel { length: string; width: string; height: string; distance_unit: 'cm' | 'in'; weight: string; mass_unit: 'g' | 'oz' | 'lb' | 'kg'; }
+interface ShippoShipmentRequest { address_from: ShippoAddress; address_to: ShippoAddress; parcels: ShippoParcel[]; }
+interface ShippoRate { object_id: string; amount: string; currency: string; provider: string; servicelevel: { token: string; name: string }; estimated_days?: number; provider_image_75?: string; }
+interface ShippoTransaction { object_id: string; status: string; tracking_number: string; tracking_url_provider: string; label_url: string; messages?: any[]; }
+interface ShippoTrack { carrier: string; tracking_number: string; tracking_status?: { status: string; status_details: string; status_date: string; location?: any; }; eta?: string; tracking_history?: any[]; }
+
+
+@Component({
+  selector: 'app-shippo-connector',
+  templateUrl: './shippo-connector.component.html',
+  styleUrls: ['./shippo-connector.component.scss']
+})
+export class ShippoConnectorComponent implements OnInit {
+  isLoadingRates = false;
+  isLoadingLabel = false;
+  isLoadingTracking = false;
+
+  // Forms
+  addressFromForm: FormGroup;
+  addressToForm: FormGroup;
+  parcelForm: FormGroup;
+  trackingForm: FormGroup;
+
+  rates: ShippoRate[] = [];
+  selectedRateId: string | null = null;
+  transactionInfo: ShippoTransaction | null = null;
+  trackingInfo: ShippoTrack | null = null;
+
+  errorMessages: string[] = [];
+
+  // Shippo carrier tokens for tracking form (examples)
+  shippoCarriers = [
+    { token: 'fedex', name: 'FedEx' },
+    { token: 'ups', name: 'UPS' },
+    { token: 'usps', name: 'USPS' },
+    { token: 'dhl_express', name: 'DHL Express' },
+    // Add more as supported by your Shippo account
+  ];
+
+  constructor(private fb: FormBuilder, private shippoService: ShippoService) {
+    this.addressFromForm = this.fb.group({
+      name: ['Sender Co.', Validators.required],
+      street1: ['1 Infinite Loop', Validators.required],
+      city: ['Cupertino', Validators.required],
+      state: ['CA', Validators.required],
+      zip: ['95014', Validators.required],
+      country: ['US', Validators.required],
+      phone: ['5551234567']
+    });
+    this.addressToForm = this.fb.group({
+      name: ['Receiver Inc.', Validators.required],
+      street1: ['1600 Amphitheatre Parkway', Validators.required],
+      city: ['Mountain View', Validators.required],
+      state: ['CA', Validators.required],
+      zip: ['94043', Validators.required],
+      country: ['US', Validators.required],
+      phone: ['5559876543']
+    });
+    this.parcelForm = this.fb.group({
+      length: ['10', Validators.required],
+      width: ['8', Validators.required],
+      height: ['6', Validators.required],
+      distance_unit: ['in', Validators.required],
+      weight: ['5', Validators.required],
+      mass_unit: ['lb', Validators.required]
+    });
+    this.trackingForm = this.fb.group({
+      carrierToken: ['fedex', Validators.required], // Default to FedEx for example
+      trackingNumber: ['', Validators.required]
+    });
+  }
+
+  ngOnInit(): void { }
+
+  getShipmentRates(): void {
+    if (this.addressFromForm.invalid || this.addressToForm.invalid || this.parcelForm.invalid) {
+      this.errorMessages = ['Please fill all required address and parcel fields.'];
+      return;
+    }
+    this.isLoadingRates = true;
+    this.rates = [];
+    this.selectedRateId = null;
+    this.transactionInfo = null;
+    this.errorMessages = [];
+
+    const shipmentRequest: ShippoShipmentRequest = {
+      address_from: this.addressFromForm.value,
+      address_to: this.addressToForm.value,
+      parcels: [this.parcelForm.value]
+    };
+
+    this.shippoService.createShipmentAndGetRates(shipmentRequest).subscribe(
+      (responseRates) => {
+        this.rates = responseRates;
+        if (this.rates.length === 0) {
+          this.errorMessages.push('No rates returned from Shippo (mock).');
+        }
+        this.isLoadingRates = false;
+      },
+      (err) => {
+        this.errorMessages.push(`Error fetching rates: ${err.message || err}`);
+        this.isLoadingRates = false;
+      }
+    );
+  }
+
+  selectRate(rateId: string): void {
+    this.selectedRateId = rateId;
+    this.transactionInfo = null; // Clear previous transaction if a new rate is selected
+  }
+
+  createLabel(): void {
+    if (!this.selectedRateId) {
+      this.errorMessages = ['Please select a shipping rate first.'];
+      return;
+    }
+    this.isLoadingLabel = true;
+    this.transactionInfo = null;
+    this.errorMessages = [];
+
+    this.shippoService.createShippingLabel({ rate: this.selectedRateId, label_file_type: 'PNG' }).subscribe(
+      (response) => {
+        this.transactionInfo = response;
+        if (!response || response.status !== 'SUCCESS') {
+            this.errorMessages.push(`Label creation failed or status is not SUCCESS (mock). Status: ${response?.status}`);
+        }
+        this.isLoadingLabel = false;
+      },
+      (err) => {
+        this.errorMessages.push(`Error creating label: ${err.message || err}`);
+        this.isLoadingLabel = false;
+      }
+    );
+  }
+
+  trackPackage(): void {
+    if (this.trackingForm.invalid) {
+      this.errorMessages = ['Please select a carrier and enter a tracking number.'];
+      return;
+    }
+    this.isLoadingTracking = true;
+    this.trackingInfo = null;
+    this.errorMessages = [];
+    const formValue = this.trackingForm.value;
+
+    this.shippoService.trackShipment({ carrier: formValue.carrierToken, tracking_number: formValue.trackingNumber }).subscribe(
+      (response) => {
+        this.trackingInfo = response;
+        if (!response) {
+            this.errorMessages.push('No tracking data returned from Shippo (mock).');
+        }
+        this.isLoadingTracking = false;
+      },
+      (err) => {
+        this.errorMessages.push(`Error tracking package: ${err.message || err}`);
+        this.isLoadingTracking = false;
+      }
+    );
+  }
+
+  getTrackingStatus(track: ShippoTrack | null): string {
+    if (!track || !track.tracking_status) return 'N/A';
+    return `${track.tracking_status.status_details} (${track.tracking_status.status_date ? new Date(track.tracking_status.status_date).toLocaleString() : 'No date'})`;
+  }
+}

--- a/src/app/modules/integrations/shopify-connector/shopify-connector.component.ts
+++ b/src/app/modules/integrations/shopify-connector/shopify-connector.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { ShopifyService } from '../../services/shopify.service'; // Changed import
-import { OrderService } from '../../services/order.service'; // Changed ItemService to OrderService
+import { ShopifyService } from '../../modules/services/shopify.service'; // Changed import
+import { OrderService } from '../../modules/services/order.service'; // Changed ItemService to OrderService
 import { Order } from '../../model/order.model';
 
 @Component({

--- a/src/app/modules/integrations/ups-connector/ups-connector.component.html
+++ b/src/app/modules/integrations/ups-connector/ups-connector.component.html
@@ -1,0 +1,158 @@
+<div class="connector-container">
+  <h2>UPS Shipping Integration</h2>
+
+  <!-- Error Messages -->
+  <div *ngIf="errorMessages.length > 0" class="error-messages alert alert-danger">
+    <h4>Errors:</h4>
+    <ul>
+      <li *ngFor="let msg of errorMessages">{{ msg }}</li>
+    </ul>
+  </div>
+
+  <!-- Get Rates Section -->
+  <mat-card class="mb-3">
+    <mat-card-header>
+      <mat-card-title>Get Shipping Rates</mat-card-title>
+    </mat-card-header>
+    <mat-card-content [formGroup]="rateForm">
+      <div class="row">
+        <div class="col-md-6">
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Shipper Postal Code</mat-label>
+            <input matInput formControlName="shipperPostalCode">
+          </mat-form-field>
+        </div>
+        <div class="col-md-6">
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Shipper Country Code</mat-label>
+            <input matInput formControlName="shipperCountryCode">
+          </mat-form-field>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-6">
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Recipient Postal Code</mat-label>
+            <input matInput formControlName="recipientPostalCode">
+          </mat-form-field>
+        </div>
+        <div class="col-md-6">
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Recipient Country Code</mat-label>
+            <input matInput formControlName="recipientCountryCode">
+          </mat-form-field>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-6">
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Package Weight</mat-label>
+            <input matInput type="text" formControlName="packageWeight"> <!-- UPS API often uses string for weight -->
+          </mat-form-field>
+        </div>
+        <div class="col-md-6">
+          <mat-form-field appearance="fill" class="w-100">
+            <mat-label>Weight Units</mat-label>
+            <mat-select formControlName="packageWeightUnits">
+              <mat-option value="LBS">LBS</mat-option>
+              <mat-option value="KGS">KGS</mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+      </div>
+      <button mat-raised-button color="primary" (click)="getRates()" [disabled]="isLoadingRates || rateForm.invalid">
+        <mat-icon>calculate</mat-icon>
+        {{ isLoadingRates ? 'Calculating...' : 'Get UPS Rates' }}
+      </button>
+    </mat-card-content>
+    <mat-card-actions *ngIf="isLoadingRates">
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+    </mat-card-actions>
+    <div *ngIf="rates.length > 0 && !isLoadingRates" class="mt-3 results-section">
+      <h4>Available Rates (Mock):</h4>
+      <ul class="list-group">
+        <li *ngFor="let rate of rates" class="list-group-item">
+          {{ rate.service?.Description || rate.service?.Code }}: {{ rate.totalCharges?.MonetaryValue | currency:rate.totalCharges?.CurrencyCode }}
+          <span *ngIf="rate.estimatedDelivery?.date"> (Est. Delivery: {{ rate.estimatedDelivery.date }})</span>
+        </li>
+      </ul>
+    </div>
+  </mat-card>
+
+  <!-- Create Label Section -->
+  <mat-card class="mb-3">
+    <mat-card-header>
+      <mat-card-title>Create UPS Shipping Label</mat-card-title>
+    </mat-card-header>
+    <mat-card-content [formGroup]="labelForm">
+      <p class="text-muted small">Uses address/weight from "Get Rates" form for this mock. Select a service.</p>
+       <mat-form-field appearance="fill" class="w-100">
+            <mat-label>UPS Service</mat-label>
+            <mat-select formControlName="serviceCode">
+              <mat-option *ngFor="let service of upsServiceCodes" [value]="service.Code">
+                {{ service.Description }} ({{ service.Code }})
+              </mat-option>
+            </mat-select>
+        </mat-form-field>
+      <button mat-raised-button color="accent" (click)="createLabel()" [disabled]="isLoadingLabel || labelForm.invalid || rateForm.invalid">
+        <mat-icon>receipt_long</mat-icon>
+        {{ isLoadingLabel ? 'Creating...' : 'Create UPS Label' }}
+      </button>
+    </mat-card-content>
+    <mat-card-actions *ngIf="isLoadingLabel">
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+    </mat-card-actions>
+    <div *ngIf="labelInfo && !isLoadingLabel" class="mt-3 results-section">
+      <h4>Label Created (Mock):</h4>
+      <p>Tracking Number: <strong>{{ labelInfo.shipmentResponse?.shipmentResults?.trackingNumber }}</strong></p>
+      <div *ngIf="labelPreviewUrl">
+        <p>Label Preview (PNG):</p>
+        <img [src]="labelPreviewUrl" alt="UPS Shipping Label Preview" class="img-fluid label-preview">
+      </div>
+    </div>
+  </mat-card>
+
+  <!-- Track Package Section -->
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Track UPS Package</mat-card-title>
+    </mat-card-header>
+    <mat-card-content [formGroup]="trackingForm">
+      <mat-form-field appearance="fill" class="w-100">
+        <mat-label>Tracking Number</mat-label>
+        <input matInput formControlName="trackingNumber">
+      </mat-form-field>
+      <button mat-raised-button color="warn" (click)="trackPackage()" [disabled]="isLoadingTracking || trackingForm.invalid">
+        <mat-icon>pin_drop</mat-icon>
+        {{ isLoadingTracking ? 'Tracking...' : 'Track UPS Package' }}
+      </button>
+    </mat-card-content>
+    <mat-card-actions *ngIf="isLoadingTracking">
+      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+    </mat-card-actions>
+    <div *ngIf="trackingInfo && trackingInfo.shipment && trackingInfo.shipment[0]?.package[0] && !isLoadingTracking" class="mt-3 results-section">
+      <ng-container *ngVar="trackingInfo.shipment[0].package[0] as pkg">
+        <h4>Tracking Information for {{ pkg.trackingNumber }} (Mock):</h4>
+        <p>Latest Activity: {{ getLatestActivity(pkg) }}</p>
+        <p>Delivered On: {{ getDeliveryDate(pkg) }}</p>
+        <!-- Detailed activity list if needed -->
+        <!--
+        <h5>Activity:</h5>
+        <ul>
+          <li *ngFor="let act of pkg.activity">
+            {{act.status.Description}} - {{act.date}} {{act.time}}
+            <span *ngIf="act.location?.address?.City">, {{act.location.address.City}}</span>
+          </li>
+        </ul>
+        -->
+      </ng-container>
+    </div>
+  </mat-card>
+
+   <div class="integration-details mt-4">
+    <p><em>Note: This UPS integration currently uses mock data and simulates API calls. Full API connectivity is pending. Address information for label creation is simplified. Remember to replace placeholder shipper numbers.</em></p>
+  </div>
+</div>
+
+<!-- Helper directive for ng-container variable -->
+<ng-template ngVar let-variable="ngVar" [ngVar]="null"></ng-template>

--- a/src/app/modules/integrations/ups-connector/ups-connector.component.scss
+++ b/src/app/modules/integrations/ups-connector/ups-connector.component.scss
@@ -1,0 +1,142 @@
+// Reusing FedEx connector styles for consistency, as the layout is similar.
+// Specific UPS branding/styles can be added or overridden here.
+
+.connector-container {
+  padding: 20px;
+  max-width: 900px;
+  margin: auto;
+}
+
+mat-card {
+  margin-bottom: 20px; /* Spacing between cards */
+}
+
+.w-100 {
+  width: 100%;
+}
+
+.mb-3 {
+  margin-bottom: 1rem !important;
+}
+
+.mt-3 {
+  margin-top: 1rem !important;
+}
+
+.mt-4 {
+  margin-top: 1.5rem !important;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -15px;
+  margin-left: -15px;
+}
+
+.col-md-6 {
+  position: relative;
+  width: 100%;
+  padding-right: 15px;
+  padding-left: 15px;
+  flex: 0 0 50%;
+  max-width: 50%;
+}
+
+button mat-icon {
+  margin-right: 8px;
+}
+
+mat-progress-bar {
+  margin-top: 10px; /* Space above progress bar in card actions */
+}
+
+.results-section {
+  padding: 15px;
+  background-color: #f8f9fa; // Neutral background for results
+  border-radius: 4px;
+  border: 1px solid #e9ecef;
+}
+
+.results-section h4 {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.error-messages {
+  margin-bottom: 15px;
+}
+
+.error-messages h4 {
+  margin-top: 0;
+}
+
+.error-messages ul {
+  padding-left: 20px;
+  margin-bottom: 0;
+}
+
+.label-preview {
+  max-width: 100%;
+  height: auto;
+  border: 1px solid #ccc;
+  margin-top: 10px;
+  background-color: white; // Ensure label background is white if it's transparent
+}
+
+.integration-details {
+  padding: 15px;
+  background-color: #FFF9C4; // Light yellow, reminiscent of UPS gold/brown, but softer
+  border: 1px solid #FFF176;
+  border-radius: 4px;
+  font-size: 0.9em;
+  color: #795548; // Brownish text
+}
+
+/* Basic alert styling if not globally available via Bootstrap */
+.alert {
+  position: relative;
+  padding: .75rem 1.25rem;
+  margin-bottom: 1rem;
+  border: 1px solid transparent;
+  border-radius: .25rem;
+}
+.alert-danger {
+  color: #721c24;
+  background-color: #f8d7da;
+  border-color: #f5c6cb;
+}
+
+/* Basic list group styling */
+.list-group {
+  display: flex;
+  flex-direction: column;
+  padding-left: 0;
+  margin-bottom: 0;
+}
+.list-group-item {
+  position: relative;
+  display: block;
+  padding: .75rem 1.25rem;
+  background-color: #fff;
+  border: 1px solid rgba(0,0,0,.125);
+}
+.list-group-item:first-child {
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+}
+.list-group-item:last-child {
+  border-bottom-right-radius: inherit;
+  border-bottom-left-radius: inherit;
+  margin-bottom: -1px;
+}
+.list-group-item + .list-group-item {
+  border-top-width: 0;
+}
+.text-muted {
+    color: #6c757d !important;
+}
+.small {
+    font-size: 80%;
+    font-weight: 400;
+}

--- a/src/app/modules/integrations/ups-connector/ups-connector.component.spec.ts
+++ b/src/app/modules/integrations/ups-connector/ups-connector.component.spec.ts
@@ -1,0 +1,209 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+
+import { UpsConnectorComponent } from './ups-connector.component';
+import { UPSService } from '../../services/ups.service';
+
+// Material Modules
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+// Mock UPSService
+class MockUPSService {
+  getShippingRates = jasmine.createSpy('getShippingRates').and.returnValue(of([]));
+  createShippingLabel = jasmine.createSpy('createShippingLabel').and.returnValue(of(null));
+  trackShipment = jasmine.createSpy('trackShipment').and.returnValue(of(null));
+}
+
+describe('UpsConnectorComponent', () => {
+  let component: UpsConnectorComponent;
+  let fixture: ComponentFixture<UpsConnectorComponent>;
+  let upsService: MockUPSService;
+
+  const mockRatesResponse = [{ service: { Code: '03', Description: 'UPS Ground' }, totalCharges: { MonetaryValue: '12.75', CurrencyCode: 'USD' } }];
+  const mockLabelApiResponse = { shipmentResponse: { shipmentResults: { trackingNumber: '1ZTRACKING', packageResults: { shippingLabel: { ImageFormat: { Code: 'PNG' }, GraphicImage: 'base64==' } } } } };
+  const mockTrackingApiResponse = { shipment: [{ package: [{ trackingNumber: '1ZTRACKING', activity: [{ status: {Type: 'D', Description: 'Delivered'}, date: '20230101', time:'120000'}] }] }] };
+
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [UpsConnectorComponent],
+      imports: [
+        ReactiveFormsModule,
+        NoopAnimationsModule,
+        MatCardModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatSelectModule,
+        MatButtonModule,
+        MatProgressBarModule,
+        MatIconModule,
+        MatListModule
+      ],
+      providers: [
+        { provide: UPSService, useClass: MockUPSService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UpsConnectorComponent);
+    component = fixture.componentInstance;
+    upsService = TestBed.inject(UPSService) as unknown as MockUPSService;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('getRates', () => {
+    it('should not call service if rateForm is invalid', () => {
+      component.rateForm.controls['shipperPostalCode'].setValue('');
+      component.getRates();
+      expect(upsService.getShippingRates).not.toHaveBeenCalled();
+      expect(component.errorMessages).toContain('Rate form is invalid.');
+    });
+
+    it('should call upsService.getShippingRates and populate rates if form is valid', fakeAsync(() => {
+      upsService.getShippingRates.and.returnValue(of(mockRatesResponse));
+      component.getRates(); // Form is valid by default
+      tick();
+
+      expect(upsService.getShippingRates).toHaveBeenCalled();
+      expect(component.rates.length).toBe(1);
+      expect(component.rates[0].service.Code).toBe('03');
+      expect(component.isLoadingRates).toBeFalse();
+    }));
+
+     it('should handle empty rates response', fakeAsync(() => {
+      upsService.getShippingRates.and.returnValue(of([]));
+      component.getRates();
+      tick();
+      expect(component.rates.length).toBe(0);
+      expect(component.errorMessages).toContain('No rates returned from UPS (mock).');
+      expect(component.isLoadingRates).toBeFalse();
+    }));
+
+    it('should handle error from getShippingRates', fakeAsync(() => {
+      upsService.getShippingRates.and.returnValue(throwError(() => new Error('UPS Rate API Error')));
+      component.getRates();
+      tick();
+      expect(component.errorMessages).toContain('Error fetching rates: UPS Rate API Error');
+      expect(component.isLoadingRates).toBeFalse();
+    }));
+  });
+
+  describe('createLabel', () => {
+    it('should not call service if labelForm or rateForm is invalid', () => {
+      component.labelForm.controls['serviceCode'].setValue(''); // Invalid
+      component.createLabel();
+      expect(upsService.createShippingLabel).not.toHaveBeenCalled();
+      expect(component.errorMessages).toContain('Label or address/weight form is invalid.');
+
+      component.labelForm.controls['serviceCode'].setValue('03'); // Valid
+      component.rateForm.controls['shipperPostalCode'].setValue(''); // rateForm invalid
+      component.createLabel();
+      expect(upsService.createShippingLabel).not.toHaveBeenCalled(); // Still not called
+    });
+
+    it('should call upsService.createShippingLabel and set labelInfo/labelPreviewUrl', fakeAsync(() => {
+      upsService.createShippingLabel.and.returnValue(of(mockLabelApiResponse as any));
+      // Ensure forms are valid
+      component.rateForm.patchValue({ shipperPostalCode: '90210', shipperCountryCode: 'US', recipientPostalCode: '10001', recipientCountryCode: 'US', packageWeight: '5', packageWeightUnits: 'LBS' });
+      component.labelForm.patchValue({ serviceCode: '03' });
+      component.createLabel();
+      tick();
+
+      expect(upsService.createShippingLabel).toHaveBeenCalled();
+      expect(component.labelInfo).toEqual(mockLabelApiResponse as any);
+      expect(component.labelPreviewUrl).toBe('data:image/png;base64,' + mockLabelApiResponse.shipmentResponse.shipmentResults.packageResults.shippingLabel.GraphicImage);
+      expect(component.isLoadingLabel).toBeFalse();
+    }));
+
+    it('should handle null response from createShippingLabel', fakeAsync(() => {
+      upsService.createShippingLabel.and.returnValue(of(null));
+      component.createLabel(); // Assuming forms are valid
+      tick();
+      expect(component.labelInfo).toBeNull();
+      expect(component.labelPreviewUrl).toBeNull();
+      expect(component.errorMessages).toContain('No label data returned from UPS (mock).');
+      expect(component.isLoadingLabel).toBeFalse();
+    }));
+
+
+    it('should handle error from createShippingLabel', fakeAsync(() => {
+      upsService.createShippingLabel.and.returnValue(throwError(() => new Error('UPS Label API Error')));
+      component.createLabel(); // Assuming forms are valid
+      tick();
+      expect(component.errorMessages).toContain('Error creating label: UPS Label API Error');
+      expect(component.isLoadingLabel).toBeFalse();
+    }));
+  });
+
+  describe('trackPackage', () => {
+    it('should not call service if trackingForm is invalid', () => {
+      component.trackingForm.controls['trackingNumber'].setValue('');
+      component.trackPackage();
+      expect(upsService.trackShipment).not.toHaveBeenCalled();
+      expect(component.errorMessages).toContain('Tracking form is invalid.');
+    });
+
+    it('should call upsService.trackShipment and set trackingInfo', fakeAsync(() => {
+      upsService.trackShipment.and.returnValue(of(mockTrackingApiResponse as any));
+      component.trackingForm.controls['trackingNumber'].setValue('1ZTRACKING');
+      component.trackPackage();
+      tick();
+
+      expect(upsService.trackShipment).toHaveBeenCalledWith({ trackingNumber: '1ZTRACKING' });
+      expect(component.trackingInfo).toEqual(mockTrackingApiResponse as any);
+      expect(component.isLoadingTracking).toBeFalse();
+    }));
+
+    it('should handle unexpected/null response from trackShipment', fakeAsync(() => {
+      upsService.trackShipment.and.returnValue(of(null));
+      component.trackingForm.controls['trackingNumber'].setValue('1ZTRACKING');
+      component.trackPackage();
+      tick();
+      expect(component.trackingInfo).toBeNull();
+      expect(component.errorMessages).toContain('No tracking data returned or in unexpected format from UPS (mock).');
+      expect(component.isLoadingTracking).toBeFalse();
+    }));
+
+    it('should handle error from trackShipment', fakeAsync(() => {
+      upsService.trackShipment.and.returnValue(throwError(() => new Error('UPS Track API Error')));
+      component.trackingForm.controls['trackingNumber'].setValue('1ZTRACKING');
+      component.trackPackage();
+      tick();
+      expect(component.errorMessages).toContain('Error tracking package: UPS Track API Error');
+      expect(component.isLoadingTracking).toBeFalse();
+    }));
+  });
+
+  describe('Helper methods for tracking display', () => {
+    it('getLatestActivity should format correctly', () => {
+      const pkg = mockTrackingApiResponse.shipment[0].package[0];
+      const activityString = component.getLatestActivity(pkg);
+      expect(activityString).toContain('Delivered on 20230101 at 120000');
+    });
+     it('getLatestActivity should return default if no activity', () => {
+      const activityString = component.getLatestActivity({ activity: [] } as any); // Cast for test
+      expect(activityString).toBe('No activity found.');
+    });
+
+    it('getDeliveryDate should return date if delivered', () => {
+       const pkgWithDelivery = { deliveryDate: [{ type: "DEL", date: "20231025" }] };
+       expect(component.getDeliveryDate(pkgWithDelivery)).toBe("20231025");
+    });
+     it('getDeliveryDate should return default if not delivered', () => {
+       expect(component.getDeliveryDate({} as any)).toBe("Not yet delivered.");
+    });
+  });
+
+});

--- a/src/app/modules/integrations/ups-connector/ups-connector.component.ts
+++ b/src/app/modules/integrations/ups-connector/ups-connector.component.ts
@@ -1,0 +1,209 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { UPSService } from '../../services/ups.service'; // Assuming service in modules/services
+
+// Re-declare or import interfaces if not exported from service
+interface UPSRateRequest { /* ... */ }
+interface UPSRateResponse {
+  service: { Code: string, Description?: string };
+  totalCharges: { MonetaryValue: string, CurrencyCode: string };
+  estimatedDelivery?: { date: string, time?: string };
+}
+interface UPSLabelResponse {
+  shipmentResponse: {
+    shipmentResults: {
+      trackingNumber: string;
+      packageResults: { shippingLabel: { ImageFormat: { Code: string }, GraphicImage: string } };
+    }
+  }
+}
+interface UPSTrackingResponse { /* ... simplified for brevity */
+  shipment: [{
+    package: [{
+      trackingNumber: string;
+      activity: Array<{ status: { Type: string, Description: string }, date: string, time: string, location?: any }>;
+      deliveryDate?: any[];
+    }];
+  }];
+}
+
+
+@Component({
+  selector: 'app-ups-connector',
+  templateUrl: './ups-connector.component.html',
+  styleUrls: ['./ups-connector.component.scss']
+})
+export class UpsConnectorComponent implements OnInit {
+  isLoadingRates = false;
+  isLoadingLabel = false;
+  isLoadingTracking = false;
+
+  rateForm: FormGroup;
+  labelForm: FormGroup; // Simplified
+  trackingForm: FormGroup;
+
+  rates: UPSRateResponse[] = [];
+  labelInfo: UPSLabelResponse | null = null;
+  trackingInfo: UPSTrackingResponse | null = null;
+  labelPreviewUrl: string | null = null;
+
+  errorMessages: string[] = [];
+
+  // Common UPS Service Codes for dropdown
+  upsServiceCodes = [
+    { Code: '01', Description: 'UPS Next Day Air' },
+    { Code: '02', Description: 'UPS 2nd Day Air' },
+    { Code: '03', Description: 'UPS Ground' },
+    { Code: '12', Description: 'UPS 3 Day Select' },
+    { Code: '13', Description: 'UPS Next Day Air Saver' },
+    { Code: '14', Description: 'UPS Next Day Air Early' },
+    { Code: '59', Description: 'UPS 2nd Day Air A.M.' },
+    // Add more as needed, including international
+  ];
+
+  constructor(private fb: FormBuilder, private upsService: UPSService) {
+    this.rateForm = this.fb.group({
+      shipperPostalCode: ['90210', Validators.required],
+      shipperCountryCode: ['US', Validators.required],
+      recipientPostalCode: ['10001', Validators.required],
+      recipientCountryCode: ['US', Validators.required],
+      packageWeight: ['5', [Validators.required, Validators.pattern(/^\d+(\.\d+)?$/)]],
+      packageWeightUnits: ['LBS', Validators.required]
+    });
+
+    this.labelForm = this.fb.group({
+      serviceCode: ['03', Validators.required] // Default to UPS Ground
+    });
+
+    this.trackingForm = this.fb.group({
+      trackingNumber: ['', Validators.required]
+    });
+  }
+
+  ngOnInit(): void { }
+
+  getRates(): void {
+    if (this.rateForm.invalid) {
+      this.errorMessages = ['Rate form is invalid.'];
+      return;
+    }
+    this.isLoadingRates = true;
+    this.rates = [];
+    this.errorMessages = [];
+    const formVal = this.rateForm.value;
+
+    const rateRequest: UPSRateRequest = {
+      shipper: { address: { PostalCode: formVal.shipperPostalCode, CountryCode: formVal.shipperCountryCode } },
+      shipTo: { address: { PostalCode: formVal.recipientPostalCode, CountryCode: formVal.recipientCountryCode } },
+      package: {
+        packageWeight: { Weight: formVal.packageWeight, UnitOfMeasurement: { Code: formVal.packageWeightUnits } },
+        packagingType: { Code: '02' } // 02 for Your Packaging
+      }
+      // service field can be omitted to get all applicable rates, or specified
+    };
+
+    this.upsService.getShippingRates(rateRequest as any).subscribe( // Cast as any due to simplified interface
+      (response) => {
+        this.rates = response;
+        if (this.rates.length === 0) {
+          this.errorMessages.push('No rates returned from UPS (mock).');
+        }
+        this.isLoadingRates = false;
+      },
+      (err) => {
+        this.errorMessages.push(`Error fetching rates: ${err.message || err}`);
+        this.isLoadingRates = false;
+      }
+    );
+  }
+
+  createLabel(): void {
+    if (this.labelForm.invalid || this.rateForm.invalid) { // Also check rate form for address info
+      this.errorMessages = ['Label or address/weight form is invalid.'];
+      return;
+    }
+    this.isLoadingLabel = true;
+    this.labelInfo = null;
+    this.labelPreviewUrl = null;
+    this.errorMessages = [];
+
+    const rateVal = this.rateForm.value;
+    const labelVal = this.labelForm.value;
+
+    const labelRequest = { // This is a simplified structure for UPSLabelRequest
+      shipmentRequest: {
+        shipment: {
+          shipper: { Name: 'Mock Sender', ShipperNumber: 'YOUR_SHIPPER_NUMBER', Address: { AddressLine: '123 Sender Ln', City: 'Beverly Hills', StateProvinceCode: 'CA', PostalCode: rateVal.shipperPostalCode, CountryCode: rateVal.shipperCountryCode }, Phone: {Number: '1234567890'} },
+          shipTo: { Name: 'Mock Recipient', Address: { AddressLine: '456 Recipient Rd', City: 'New York', StateProvinceCode: 'NY', PostalCode: rateVal.recipientPostalCode, CountryCode: rateVal.recipientCountryCode }, Phone: {Number: '0987654321'} },
+          service: { Code: labelVal.serviceCode },
+          package: {
+            packagingType: { Code: '02' }, // Your Packaging
+            packageWeight: { Weight: rateVal.packageWeight, UnitOfMeasurement: { Code: rateVal.packageWeightUnits } }
+          },
+          paymentInformation: { shipmentCharge: { type: '01', billShipper: { accountNumber: 'YOUR_SHIPPER_NUMBER' } } }, // Bill Shipper
+          labelSpecification: {
+            LabelImageFormat: { Code: 'PNG' }, // Request PNG for preview
+            LabelStockSize: { Height: '6', Width: '4' }
+          }
+        }
+      }
+    };
+
+    this.upsService.createShippingLabel(labelRequest as any).subscribe( // Cast as any
+      (response) => {
+        this.labelInfo = response;
+        if (response?.shipmentResponse?.shipmentResults?.packageResults?.shippingLabel?.GraphicImage) {
+          this.labelPreviewUrl = 'data:image/png;base64,' + response.shipmentResponse.shipmentResults.packageResults.shippingLabel.GraphicImage;
+        } else if (!response) {
+          this.errorMessages.push('No label data returned from UPS (mock).');
+        }
+        this.isLoadingLabel = false;
+      },
+      (err) => {
+        this.errorMessages.push(`Error creating label: ${err.message || err}`);
+        this.isLoadingLabel = false;
+      }
+    );
+  }
+
+  trackPackage(): void {
+    if (this.trackingForm.invalid) {
+      this.errorMessages = ['Tracking form is invalid.'];
+      return;
+    }
+    this.isLoadingTracking = true;
+    this.trackingInfo = null;
+    this.errorMessages = [];
+    const formVal = this.trackingForm.value;
+
+    this.upsService.trackShipment({ trackingNumber: formVal.trackingNumber }).subscribe(
+      (response) => {
+        this.trackingInfo = response;
+        if (!response || !response.shipment || response.shipment.length === 0 || !response.shipment[0].package || response.shipment[0].package.length === 0) {
+            this.errorMessages.push('No tracking data returned or in unexpected format from UPS (mock).');
+        }
+        this.isLoadingTracking = false;
+      },
+      (err) => {
+        this.errorMessages.push(`Error tracking package: ${err.message || err}`);
+        this.isLoadingTracking = false;
+      }
+    );
+  }
+
+  // Helper to display tracking activity
+  getLatestActivity(pkg: any): string {
+    if (pkg && pkg.activity && pkg.activity.length > 0) {
+      const latest = pkg.activity[0]; // UPS usually returns most recent first
+      return `${latest.status.Description} on ${latest.date} at ${latest.time} in ${latest.location?.address?.City || 'N/A'}`;
+    }
+    return 'No activity found.';
+  }
+
+  getDeliveryDate(pkg: any): string {
+    if(pkg && pkg.deliveryDate && pkg.deliveryDate.length > 0 && pkg.deliveryDate[0].type === 'DEL') {
+      return pkg.deliveryDate[0].date;
+    }
+    return 'Not yet delivered.';
+  }
+}

--- a/src/app/modules/integrations/xero-connector/xero-connector.component.html
+++ b/src/app/modules/integrations/xero-connector/xero-connector.component.html
@@ -1,0 +1,61 @@
+<div class="connector-container">
+  <h2>Xero Integration</h2>
+
+  <div class="sync-section">
+    <button (click)="syncDataToXero()" [disabled]="isLoading" mat-raised-button color="primary" class="mr-2">
+      <mat-icon>sync</mat-icon>
+      {{ isLoading ? 'Syncing Data...' : 'Sync Data to Xero' }}
+    </button>
+    <button (click)="fetchInvoicesFromXero()" [disabled]="isLoading" mat-raised-button>
+      <mat-icon>cloud_download</mat-icon>
+      {{ isLoading ? 'Fetching Invoices...' : 'Fetch Invoices from Xero' }}
+    </button>
+  </div>
+
+  <mat-progress-bar mode="indeterminate" *ngIf="isLoading"></mat-progress-bar>
+
+  <div class="sync-info" *ngIf="lastSyncTime && !isLoading">
+    <p>Last sync/fetch attempt: {{ lastSyncTime | date:'medium' }}</p>
+  </div>
+
+  <div *ngIf="successMessages.length > 0 && !isLoading" class="success-messages">
+    <h4>Sync/Fetch Report:</h4>
+    <ul>
+      <li *ngFor="let msg of successMessages">{{ msg }}</li>
+    </ul>
+  </div>
+
+  <div *ngIf="errorMessages.length > 0 && !isLoading" class="error-messages">
+    <h4>Errors:</h4>
+    <ul>
+      <li *ngFor="let msg of errorMessages">{{ msg }}</li>
+    </ul>
+  </div>
+
+  <div *ngIf="xeroInvoices.length > 0 && !isLoading" class="mt-4">
+    <h3>Fetched Xero Invoices (Mock Data)</h3>
+    <ul class="list-group">
+      <li *ngFor="let invoice of xeroInvoices" class="list-group-item">
+        ID: {{invoice.InvoiceID || 'N/A'}}, Num: {{invoice.InvoiceNumber || 'N/A'}}, Contact: {{invoice.Contact?.Name}}, Total: {{invoice.Total | currency}}, Status: {{invoice.Status}}
+        <div *ngIf="invoice.LineItems && invoice.LineItems.length > 0">
+          Items:
+          <ul>
+            <li *ngFor="let item of invoice.LineItems">
+              {{item.Description || 'Unknown Item'}}: {{item.LineAmount | currency}} (Qty: {{item.Quantity || 1}})
+            </li>
+          </ul>
+        </div>
+      </li>
+    </ul>
+  </div>
+
+  <div class="integration-details mt-4">
+    <h3>Configuration (Placeholder)</h3>
+    <p>
+      Xero integration enables syncing invoices, payments, and contacts/customers between your application and Xero.
+    </p>
+    <p>
+      <em>Note: This integration currently uses mock data and simulates API calls. Full API connectivity is pending.</em>
+    </p>
+  </div>
+</div>

--- a/src/app/modules/integrations/xero-connector/xero-connector.component.scss
+++ b/src/app/modules/integrations/xero-connector/xero-connector.component.scss
@@ -1,0 +1,105 @@
+// Using the same styles as quickbooks-connector for consistency
+// If specific Xero styles are needed, they can be added here or override the shared styles.
+
+.connector-container {
+  padding: 20px;
+  max-width: 900px;
+  margin: auto;
+}
+
+.sync-section {
+  margin-bottom: 20px;
+  display: flex;
+  gap: 10px; /* Space between buttons */
+}
+
+.sync-section button mat-icon {
+  margin-right: 8px;
+}
+
+mat-progress-bar {
+  margin-bottom: 20px;
+}
+
+.sync-info {
+  margin-top: 15px;
+  padding: 10px;
+  background-color: #f0f0f0;
+  border-radius: 4px;
+  border: 1px solid #e0e0e0;
+  font-size: 0.9em;
+}
+
+.success-messages, .error-messages {
+  margin-top: 15px;
+  padding: 10px;
+  border-radius: 4px;
+}
+
+.success-messages {
+  background-color: #e8f5e9; /* Light green */
+  border: 1px solid #a5d6a7;
+  color: #2e7d32; /* Darker green */
+}
+
+.error-messages {
+  background-color: #ffebee; /* Light red */
+  border: 1px solid #ef9a9a;
+  color: #c62828; /* Darker red */
+}
+
+.success-messages h4, .error-messages h4 {
+  margin-top: 0;
+}
+
+.success-messages ul, .error-messages ul {
+  padding-left: 20px;
+  margin-bottom: 0;
+}
+
+.integration-details {
+  margin-top: 20px;
+  padding: 15px;
+  background-color: #e3f2fd; /* Light blue for Xero, same as QB for now */
+  border: 1px solid #90caf9;
+  border-radius: 4px;
+}
+
+.integration-details h3 {
+  margin-top: 0;
+  color: #0d47a1; /* Dark blue */
+}
+
+/* Basic styling for list groups if bootstrap is not fully available */
+.list-group {
+  padding-left: 0;
+  margin-bottom: 20px;
+}
+
+.list-group-item {
+  position: relative;
+  display: block;
+  padding: 0.75rem 1.25rem;
+  background-color: #fff;
+  border: 1px solid rgba(0,0,0,.125);
+}
+
+.list-group-item:first-child {
+  border-top-left-radius: .25rem;
+  border-top-right-radius: .25rem;
+}
+
+.list-group-item:last-child {
+  border-bottom-right-radius: .25rem;
+  border-bottom-left-radius: .25rem;
+  margin-bottom: 0;
+  border-bottom-width: 1px;
+}
+
+.list-group-item + .list-group-item {
+  border-top-width: 0;
+}
+
+.mr-2 {
+  margin-right: 0.5rem;
+}

--- a/src/app/modules/integrations/xero-connector/xero-connector.component.spec.ts
+++ b/src/app/modules/integrations/xero-connector/xero-connector.component.spec.ts
@@ -1,0 +1,155 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of, throwError } from 'rxjs';
+
+import { XeroConnectorComponent } from './xero-connector.component';
+import { XeroService } from '../../services/xero.service';
+
+// Material Modules
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+class MockXeroService {
+  syncInvoicesToXero = jasmine.createSpy('syncInvoicesToXero').and.returnValue(of(true));
+  syncPaymentsToXero = jasmine.createSpy('syncPaymentsToXero').and.returnValue(of(true));
+  syncContactsToXero = jasmine.createSpy('syncContactsToXero').and.returnValue(of(true));
+  fetchInvoicesFromXero = jasmine.createSpy('fetchInvoicesFromXero').and.returnValue(of([]));
+}
+
+describe('XeroConnectorComponent', () => {
+  let component: XeroConnectorComponent;
+  let fixture: ComponentFixture<XeroConnectorComponent>;
+  let xeroService: MockXeroService;
+
+  const mockRawXeroInvoice = { InvoiceID: "x1", Type: "ACCREC", Contact: { Name: "Test Xero Cust" }, Total: 100, Status: "AUTHORISED" };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [XeroConnectorComponent],
+      imports: [
+        ReactiveFormsModule, // Not strictly needed by this component's TS but good for consistency if template uses it
+        NoopAnimationsModule,
+        MatCardModule,
+        MatButtonModule,
+        MatProgressBarModule,
+        MatIconModule,
+        MatListModule
+      ],
+      providers: [
+        { provide: XeroService, useClass: MockXeroService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(XeroConnectorComponent);
+    component = fixture.componentInstance;
+    xeroService = TestBed.inject(XeroService) as unknown as MockXeroService;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('syncDataToXero', () => {
+    it('should set isLoading to true and reset messages', () => {
+      component.syncDataToXero();
+      expect(component.isLoading).toBeTrue();
+      expect(component.errorMessages.length).toBe(0);
+      expect(component.successMessages.length).toBe(0);
+    });
+
+    it('should call all sync methods on XeroService', fakeAsync(() => {
+      component.syncDataToXero();
+      tick(); // Resolve all observables
+
+      expect(xeroService.syncInvoicesToXero).toHaveBeenCalled();
+      expect(xeroService.syncPaymentsToXero).toHaveBeenCalled();
+      expect(xeroService.syncContactsToXero).toHaveBeenCalled();
+
+      expect(component.successMessages.length).toBe(3);
+      expect(component.isLoading).toBeFalse();
+      expect(component.lastSyncTime).not.toBeNull();
+    }));
+
+    it('should handle errors from syncContactsToXero', fakeAsync(() => {
+      xeroService.syncContactsToXero.and.returnValue(throwError(() => new Error('Contact sync failed')));
+      component.syncDataToXero();
+      tick();
+
+      expect(component.errorMessages).toContain('Error syncing contacts to Xero: Contact sync failed');
+      expect(component.isLoading).toBeFalse();
+    }));
+
+    it('should handle false return from syncInvoicesToXero', fakeAsync(() => {
+      xeroService.syncInvoicesToXero.and.returnValue(of(false));
+      component.syncDataToXero();
+      tick();
+      expect(component.errorMessages).toContain('Failed to sync invoices to Xero (mock).');
+      expect(component.isLoading).toBeFalse();
+    }));
+  });
+
+  describe('fetchInvoicesFromXero', () => {
+    it('should set isLoading and reset messages/data', () => {
+      component.fetchInvoicesFromXero();
+      expect(component.isLoading).toBeTrue();
+      expect(component.errorMessages.length).toBe(0);
+      expect(component.successMessages.length).toBe(0);
+      expect(component.xeroInvoices.length).toBe(0);
+    });
+
+    it('should call fetchInvoicesFromXero and populate xeroInvoices', fakeAsync(() => {
+      xeroService.fetchInvoicesFromXero.and.returnValue(of([mockRawXeroInvoice]));
+      component.fetchInvoicesFromXero();
+      tick();
+
+      expect(xeroService.fetchInvoicesFromXero).toHaveBeenCalled();
+      expect(component.xeroInvoices.length).toBe(1);
+      expect(component.xeroInvoices[0].InvoiceID).toBe("x1");
+      expect(component.successMessages).toContain('Successfully fetched 1 invoices from Xero (mock).');
+      expect(component.isLoading).toBeFalse();
+      expect(component.lastSyncTime).not.toBeNull();
+    }));
+
+    it('should handle empty array from fetchInvoicesFromXero', fakeAsync(() => {
+        xeroService.fetchInvoicesFromXero.and.returnValue(of([]));
+        component.fetchInvoicesFromXero();
+        tick();
+        expect(component.successMessages).toContain('No invoices found in Xero (mock) or an error occurred during fetch.');
+        expect(component.isLoading).toBeFalse();
+    }));
+
+
+    it('should handle errors from fetchInvoicesFromXero', fakeAsync(() => {
+      xeroService.fetchInvoicesFromXero.and.returnValue(throwError(() => new Error('Fetch Xero invoices failed')));
+      component.fetchInvoicesFromXero();
+      tick();
+
+      expect(component.errorMessages).toContain('Error fetching invoices from Xero: Fetch Xero invoices failed');
+      expect(component.isLoading).toBeFalse();
+    }));
+  });
+
+
+  describe('checkCompletion private method', () => {
+    it('should set isLoading to false and update lastSyncTime when all operations complete', () => {
+      component.isLoading = true;
+      component.lastSyncTime = null;
+      (component as any).checkCompletion(3, 3);
+      expect(component.isLoading).toBeFalse();
+      expect(component.lastSyncTime).not.toBeNull();
+    });
+
+    it('should not change isLoading if not all operations are complete', () => {
+      component.isLoading = true;
+      component.lastSyncTime = null;
+      (component as any).checkCompletion(1, 3);
+      expect(component.isLoading).toBeTrue();
+      expect(component.lastSyncTime).toBeNull();
+    });
+  });
+});

--- a/src/app/modules/integrations/xero-connector/xero-connector.component.ts
+++ b/src/app/modules/integrations/xero-connector/xero-connector.component.ts
@@ -1,0 +1,108 @@
+import { Component, OnInit } from '@angular/core';
+import { XeroService } from '../../services/xero.service'; // Assuming service is in modules/services
+
+@Component({
+  selector: 'app-xero-connector',
+  templateUrl: './xero-connector.component.html',
+  styleUrls: ['./xero-connector.component.scss']
+})
+export class XeroConnectorComponent implements OnInit {
+  isLoading: boolean = false;
+  lastSyncTime: Date | null = null;
+  errorMessages: string[] = [];
+  successMessages: string[] = [];
+
+  xeroInvoices: any[] = []; // To store fetched Xero invoices
+
+  constructor(private xeroService: XeroService) { }
+
+  ngOnInit(): void {
+  }
+
+  syncDataToXero(): void {
+    this.isLoading = true;
+    this.errorMessages = [];
+    this.successMessages = [];
+    let operationsCompleted = 0;
+    const totalOperations = 3; // Invoices, Payments, Contacts
+
+    // Mock data from your application
+    const mockAppInvoices = [{ id: 'appInvX1', amount: 200, customerName: 'App Cust X' }];
+    const mockAppPayments = [{ id: 'appPayX1', amount: 200, invoiceId: 'appInvX1' }];
+    const mockAppContacts = [{ id: 'appContactX1', name: 'App Customer Xero' }];
+
+    this.xeroService.syncInvoicesToXero(mockAppInvoices).subscribe(
+      success => {
+        if (success) this.successMessages.push('Invoices synced to Xero successfully (mock).');
+        else this.errorMessages.push('Failed to sync invoices to Xero (mock).');
+        operationsCompleted++;
+        this.checkCompletion(operationsCompleted, totalOperations);
+      },
+      err => {
+        this.errorMessages.push(`Error syncing invoices to Xero: ${err.message || err}`);
+        operationsCompleted++;
+        this.checkCompletion(operationsCompleted, totalOperations);
+      }
+    );
+
+    this.xeroService.syncPaymentsToXero(mockAppPayments).subscribe(
+      success => {
+        if (success) this.successMessages.push('Payments synced to Xero successfully (mock).');
+        else this.errorMessages.push('Failed to sync payments to Xero (mock).');
+        operationsCompleted++;
+        this.checkCompletion(operationsCompleted, totalOperations);
+      },
+      err => {
+        this.errorMessages.push(`Error syncing payments to Xero: ${err.message || err}`);
+        operationsCompleted++;
+        this.checkCompletion(operationsCompleted, totalOperations);
+      }
+    );
+
+    this.xeroService.syncContactsToXero(mockAppContacts).subscribe(
+      success => {
+        if (success) this.successMessages.push('Contacts synced to Xero successfully (mock).');
+        else this.errorMessages.push('Failed to sync contacts to Xero (mock).');
+        operationsCompleted++;
+        this.checkCompletion(operationsCompleted, totalOperations);
+      },
+      err => {
+        this.errorMessages.push(`Error syncing contacts to Xero: ${err.message || err}`);
+        operationsCompleted++;
+        this.checkCompletion(operationsCompleted, totalOperations);
+      }
+    );
+  }
+
+  fetchInvoicesFromXero(): void {
+    this.isLoading = true;
+    this.errorMessages = [];
+    this.successMessages = [];
+    this.xeroInvoices = [];
+
+    this.xeroService.fetchInvoicesFromXero().subscribe(
+      invoices => {
+        this.xeroInvoices = invoices;
+        if (invoices.length > 0) {
+          this.successMessages.push(`Successfully fetched ${invoices.length} invoices from Xero (mock).`);
+        } else {
+          this.successMessages.push('No invoices found in Xero (mock) or an error occurred during fetch.');
+        }
+        this.isLoading = false;
+        this.lastSyncTime = new Date();
+      },
+      err => {
+        this.errorMessages.push(`Error fetching invoices from Xero: ${err.message || err}`);
+        this.isLoading = false;
+        this.lastSyncTime = new Date();
+      }
+    );
+  }
+
+  private checkCompletion(completed: number, total: number): void {
+    if (completed === total) {
+      this.isLoading = false;
+      this.lastSyncTime = new Date();
+    }
+  }
+}

--- a/src/app/modules/services/amazon.service.spec.ts
+++ b/src/app/modules/services/amazon.service.spec.ts
@@ -1,0 +1,125 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { AmazonService } from './amazon.service';
+import { environment } from '../../../environments/environment';
+import { Order } from '../model/order.model'; // Assuming Order model is used
+
+describe('AmazonService', () => {
+  let service: AmazonService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AmazonService]
+    });
+    service = TestBed.inject(AmazonService);
+    httpMock = TestBed.inject(HttpTestingController);
+
+    // Mock environment config if your service uses it for URLs
+    environment.amazonMwsApiConfig = {
+      endpoint: 'https://mock-amazon-api.com',
+      mockDataUrl: '/assets/mock-amazon-orders.json' // Example mock data URL
+    };
+  });
+
+  afterEach(() => {
+    httpMock.verify(); // Verify that no unmatched requests are outstanding
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('fetchNewAmazonOrders', () => {
+    it('should fetch orders from mockDataUrl if configured', (done) => {
+      const mockRawOrders = [
+        { AmazonOrderId: '123-1', PurchaseDate: new Date().toISOString(), OrderItems: [{ OrderItemId: 'oi-1', ASIN: 'ASIN1', QuantityOrdered: 1 }] },
+        { AmazonOrderId: '123-2', PurchaseDate: new Date().toISOString(), OrderItems: [{ OrderItemId: 'oi-2', ASIN: 'ASIN2', QuantityOrdered: 2 }] }
+      ];
+      const expectedOrders: Order[] = mockRawOrders.map(rawOrder => ({
+        id: `amazon-${rawOrder.AmazonOrderId}`,
+        user_id: 'amazon_integration',
+        customer_name: 'N/A', // Simplified for this test based on current transform
+        telephone: 0,
+        delivery_address: 'N/A',
+        payment_type: 'Amazon Pay',
+        items: (rawOrder.OrderItems || []).map(item => ({
+          product_no: item.ASIN,
+          product_name: 'N/A',
+          quantity: item.QuantityOrdered,
+          item_cost: 0, // Simplified
+        })),
+        delivery_cost: 0,
+        discount: 0,
+        total_cost: 0, // Simplified
+        created_date: new Date(rawOrder.PurchaseDate).toISOString(),
+      }));
+
+
+      service.fetchNewAmazonOrders().subscribe(orders => {
+        expect(orders.length).toBe(2);
+        // Deeper comparison can be done here if needed, for now just checking length and basic structure
+        expect(orders[0].id).toEqual(expectedOrders[0].id);
+        expect(orders[1].items[0].product_no).toEqual(expectedOrders[1].items[0].product_no);
+        done();
+      });
+
+      const req = httpMock.expectOne(environment.amazonMwsApiConfig.mockDataUrl!);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockRawOrders);
+    });
+
+    it('should return hardcoded mock orders if mockDataUrl is not set but API endpoint is (and API not implemented)', (done) => {
+      environment.amazonMwsApiConfig.mockDataUrl = undefined; // Ensure mockDataUrl is not set
+      // Service should fall back to hardcoded mock data
+      const hardcodedMock = (service as any).getHardcodedMockAmazonOrders(); // Access private method for test
+
+      service.fetchNewAmazonOrders().subscribe(orders => {
+        expect(orders.length).toBe(hardcodedMock.length);
+        // Add more specific checks if necessary based on the hardcoded data
+        if (hardcodedMock.length > 0) {
+          expect(orders[0].id).toBe(`amazon-${hardcodedMock[0].AmazonOrderId}`);
+        }
+        done();
+      });
+      // No HTTP request is expected in this specific fallback path of the current service implementation
+    });
+
+    it('should return an empty array on HTTP error when using mockDataUrl', (done) => {
+      service.fetchNewAmazonOrders().subscribe(orders => {
+        expect(orders).toEqual([]);
+        done();
+      });
+
+      const req = httpMock.expectOne(environment.amazonMwsApiConfig.mockDataUrl!);
+      req.flush('Simulated HTTP error', { status: 500, statusText: 'Server Error' });
+    });
+  });
+
+  describe('syncProductListings', () => {
+    it('should return of(true) and log warning (mock implementation)', (done) => {
+      spyOn(console, 'warn');
+      service.syncProductListings([{id: 'prod1'}]).subscribe(result => {
+        expect(result).toBe(true);
+        expect(console.warn).toHaveBeenCalledWith('AmazonService: syncProductListings is not implemented yet.');
+        done();
+      });
+    });
+  });
+
+  describe('updateInventory', () => {
+    it('should return of(true) and log warning (mock implementation)', (done) => {
+      spyOn(console, 'warn');
+      service.updateInventory([{sku: 'SKU1', quantity: 10}]).subscribe(result => {
+        expect(result).toBe(true);
+        expect(console.warn).toHaveBeenCalledWith('AmazonService: updateInventory is not implemented yet.');
+        done();
+      });
+    });
+  });
+
+  // Test the private transform method indirectly via fetchNewAmazonOrders or make it public/protected if direct testing is crucial
+  // For this example, we assume its correctness is sufficiently covered by testing fetchNewAmazonOrders outputs.
+
+});

--- a/src/app/modules/services/amazon.service.ts
+++ b/src/app/modules/services/amazon.service.ts
@@ -1,0 +1,196 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { map, catchError } from 'rxjs/operators';
+import { Order, OrderItem } from '../model/order.model'; // Assuming a shared Order model
+import { environment } from '../../../environments/environment';
+
+// Placeholder for Amazon's raw order structure. This will need to be defined based on MWS API response.
+interface RawAmazonOrder {
+  AmazonOrderId: string;
+  PurchaseDate: string; // ISO 8601 format
+  LastUpdateDate: string; // ISO 8601 format
+  OrderStatus: string; // e.g., Shipped, Pending, Canceled
+  SalesChannel: string; // e.g., Amazon.com
+  ShipmentServiceLevelCategory?: string; // e.g., Standard, Expedited
+  OrderTotal?: {
+    CurrencyCode: string; // e.g., USD
+    Amount: string; // e.g., "19.99"
+  };
+  ShippingAddress?: {
+    Name: string;
+    AddressLine1?: string;
+    AddressLine2?: string;
+    City: string;
+    StateOrRegion?: string;
+    PostalCode?: string;
+    CountryCode: string;
+    Phone?: string;
+  };
+  BuyerEmail?: string;
+  BuyerName?: string;
+  // This is highly simplified. MWS ListOrderItems is a separate call.
+  // For simplicity here, we might assume items are part of a mock order object.
+  OrderItems?: RawAmazonOrderItem[];
+}
+
+interface RawAmazonOrderItem {
+  OrderItemId: string;
+  ASIN: string;
+  SKU?: string;
+  Title?: string;
+  QuantityOrdered: number;
+  ItemPrice?: { // Price of a single unit
+    CurrencyCode: string;
+    Amount: string;
+  };
+  PromotionDiscount?: {
+    CurrencyCode: string;
+    Amount: string;
+  };
+  // ... and other fields like ShippingPrice, GiftWrapPrice etc.
+}
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AmazonService {
+  private amazonApiEndpoint = environment.amazonMwsApiConfig?.endpoint; // Example path
+  private mockDataUrl = environment.amazonMwsApiConfig?.mockDataUrl; // Example path for mock data
+
+  constructor(private http: HttpClient) {
+    if (!this.amazonApiEndpoint && !this.mockDataUrl) {
+      console.warn('AmazonService: API endpoint or mockDataUrl is not configured in environment files.');
+    }
+  }
+
+  /**
+   * Fetches new orders from Amazon MWS (mock implementation).
+   * @returns An Observable stream of `Order[]`.
+   */
+  fetchNewAmazonOrders(): Observable<Order[]> {
+    if (this.mockDataUrl) {
+      return this.http.get<RawAmazonOrder[]>(this.mockDataUrl).pipe(
+        map(rawOrders => rawOrders.map(rawOrder => this.transformRawAmazonOrderToAppOrder(rawOrder))),
+        catchError(error => {
+          console.error('Error fetching mock Amazon orders:', error);
+          return of([]);
+        })
+      );
+    } else if (this.amazonApiEndpoint) {
+      console.warn('AmazonService: Actual Amazon MWS API endpoint call for orders is not implemented yet. Returning mock data.');
+      // TODO: Implement actual API call to this.amazonApiEndpoint
+      return of(this.getHardcodedMockAmazonOrders().map(rawOrder => this.transformRawAmazonOrderToAppOrder(rawOrder)));
+    } else {
+      console.error('AmazonService: No API endpoint or mock data URL configured for orders. Returning mock data.');
+      return of(this.getHardcodedMockAmazonOrders().map(rawOrder => this.transformRawAmazonOrderToAppOrder(rawOrder)));
+    }
+  }
+
+  /**
+   * Placeholder for syncing product listings with Amazon.
+   * @param products - The products to sync.
+   * @returns An Observable indicating success or failure.
+   */
+  syncProductListings(products: any[]): Observable<boolean> {
+    console.warn('AmazonService: syncProductListings is not implemented yet.');
+    // TODO: Implement actual API call
+    return of(true); // Placeholder
+  }
+
+  /**
+   * Placeholder for updating inventory levels on Amazon.
+   * @param inventoryUpdates - The inventory updates.
+   * @returns An Observable indicating success or failure.
+   */
+  updateInventory(inventoryUpdates: any[]): Observable<boolean> {
+    console.warn('AmazonService: updateInventory is not implemented yet.');
+    // TODO: Implement actual API call
+    return of(true); // Placeholder
+  }
+
+  private transformRawAmazonOrderToAppOrder(rawOrder: RawAmazonOrder): Order {
+    const orderItems: OrderItem[] = (rawOrder.OrderItems || []).map(item => ({
+      product_no: item.SKU || item.ASIN, // Prefer SKU, fallback to ASIN
+      product_name: item.Title || 'N/A',
+      quantity: item.QuantityOrdered,
+      item_cost: parseFloat(item.ItemPrice?.Amount || '0') * item.QuantityOrdered, // Line item total
+      // unit_price: parseFloat(item.ItemPrice?.Amount || '0'), // If needed
+    }));
+
+    let deliveryCost = 0; // MWS often has shipping per item or order promotion
+    // This needs to be derived carefully from MWS data (e.g. sum of item shipping or order level shipping charges)
+
+    let customerFullName = rawOrder.BuyerName || rawOrder.ShippingAddress?.Name || 'N/A';
+
+    let shippingAddressString = 'N/A';
+    if (rawOrder.ShippingAddress) {
+      const sa = rawOrder.ShippingAddress;
+      shippingAddressString = [sa.AddressLine1, sa.AddressLine2, sa.City, sa.StateOrRegion, sa.PostalCode, sa.CountryCode]
+        .filter(Boolean).join(', ');
+    }
+
+    return {
+      id: `amazon-${rawOrder.AmazonOrderId}`,
+      user_id: 'amazon_integration',
+      customer_name: customerFullName,
+      telephone: Number(rawOrder.ShippingAddress?.Phone?.replace(/\D/g, '')) || 0,
+      delivery_address: shippingAddressString,
+      payment_type: 'Amazon Pay', // General placeholder
+      items: orderItems,
+      delivery_cost: deliveryCost,
+      discount: (rawOrder.OrderItems || []).reduce((acc, item) => acc + parseFloat(item.PromotionDiscount?.Amount || '0'), 0),
+      total_cost: parseFloat(rawOrder.OrderTotal?.Amount || '0'),
+      created_date: new Date(rawOrder.PurchaseDate).toISOString(),
+      // status: rawOrder.OrderStatus, // If your Order model has a status field
+    };
+  }
+
+  private getHardcodedMockAmazonOrders(): RawAmazonOrder[] {
+    // Basic mock structure. This needs to be more detailed based on actual MWS responses.
+    // Notably, MWS ListOrderItems is a separate call per order.
+    // This mock data assumes items are pre-fetched and embedded for simplicity.
+    return [
+      {
+        AmazonOrderId: '123-1234567-1234567',
+        PurchaseDate: new Date(Date.now() - 86400000).toISOString(), // Yesterday
+        LastUpdateDate: new Date().toISOString(),
+        OrderStatus: 'Shipped',
+        SalesChannel: 'Amazon.com',
+        OrderTotal: { CurrencyCode: 'USD', Amount: '49.98' },
+        ShippingAddress: {
+          Name: 'Jane Doe',
+          AddressLine1: '456 Amazon Ave',
+          City: 'Seattle',
+          StateOrRegion: 'WA',
+          PostalCode: '98109',
+          CountryCode: 'US',
+          Phone: '206-555-0100'
+        },
+        BuyerEmail: 'jane.doe@example.com',
+        BuyerName: 'Jane Doe',
+        OrderItems: [
+          {
+            OrderItemId: 'oi-1',
+            ASIN: 'B0EXAMPLEASIN1',
+            SKU: 'SKU-AMZN-BOOK-01',
+            Title: 'The Everything Book',
+            QuantityOrdered: 1,
+            ItemPrice: { CurrencyCode: 'USD', Amount: '29.99' },
+            PromotionDiscount: { CurrencyCode: 'USD', Amount: '0.00' }
+          },
+          {
+            OrderItemId: 'oi-2',
+            ASIN: 'B0EXAMPLEASIN2',
+            SKU: 'SKU-AMZN-GADGET-02',
+            Title: 'Useful Gadget',
+            QuantityOrdered: 1,
+            ItemPrice: { CurrencyCode: 'USD', Amount: '19.99' },
+          }
+        ]
+      },
+      // Add another mock order if desired
+    ];
+  }
+}

--- a/src/app/modules/services/ebay.service.ts
+++ b/src/app/modules/services/ebay.service.ts
@@ -78,6 +78,28 @@ export class EbayService {
   }
 
   /**
+   * Placeholder for syncing product listings with eBay.
+   * @param products - The products to sync.
+   * @returns An Observable indicating success or failure.
+   */
+  syncProductListings(products: any[]): Observable<boolean> {
+    console.warn('EbayService: syncProductListings is not implemented yet.');
+    // TODO: Implement actual API call to eBay Trading API or similar for listings
+    return of(true); // Placeholder success
+  }
+
+  /**
+   * Placeholder for updating inventory levels on eBay.
+   * @param inventoryUpdates - The inventory updates (e.g., SKU and new quantity).
+   * @returns An Observable indicating success or failure.
+   */
+  updateInventory(inventoryUpdates: any[]): Observable<boolean> {
+    console.warn('EbayService: updateInventory is not implemented yet.');
+    // TODO: Implement actual API call to eBay Inventory API or Trading API for inventory
+    return of(true); // Placeholder success
+  }
+
+  /**
    * Transforms a raw order object from the eBay API format to the application's Order model.
    * @param rawOrder The raw order data from eBay.
    * @returns An Order object.

--- a/src/app/modules/services/fedex.service.spec.ts
+++ b/src/app/modules/services/fedex.service.spec.ts
@@ -1,0 +1,141 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { FedExService } from './fedex.service';
+import { environment } from '../../../environments/environment';
+
+// Define simplified interfaces for testing as used in the service
+interface FedExRateRequest {
+  shipperAddress: any;
+  recipientAddress: any;
+  packages: Array<{ weight: { value: number, units: 'LB' | 'KG' } }>;
+}
+
+interface FedExLabelRequest {
+  shipper: any; recipient: any; serviceType: string; packagingType: string;
+  packages: Array<{ weight: { value: number, units: 'LB' | 'KG' } }>;
+  labelSpecification: { imageType: 'PNG' | 'PDF' | 'ZPLII', labelStockType: string };
+}
+
+interface FedExTrackingRequest {
+  trackingNumber: string;
+}
+
+
+describe('FedExService', () => {
+  let service: FedExService;
+  let httpMock: HttpTestingController;
+
+  const mockRateRequest: FedExRateRequest = {
+    shipperAddress: { postalCode: '90210', countryCode: 'US' },
+    recipientAddress: { postalCode: '10001', countryCode: 'US' },
+    packages: [{ weight: { value: 5, units: 'LB' } }]
+  };
+
+  const mockLabelRequest: FedExLabelRequest = {
+    shipper: { name: 'Test Shipper' }, recipient: { name: 'Test Recipient' },
+    serviceType: 'FEDEX_GROUND', packagingType: 'YOUR_PACKAGING',
+    packages: [{ weight: { value: 5, units: 'LB' } }],
+    labelSpecification: { imageType: 'PNG', labelStockType: 'PAPER_4X6' }
+  };
+
+  const mockTrackingRequest: FedExTrackingRequest = { trackingNumber: '123456789012' };
+
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [FedExService]
+    });
+    service = TestBed.inject(FedExService);
+    httpMock = TestBed.inject(HttpTestingController);
+
+    environment.fedexApiConfig = { // Ensure this is defined for tests
+      endpoint: 'https://mock-fedex-api.com'
+      // mockRateDataUrl: undefined // if you had specific mock files
+    };
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getShippingRates', () => {
+    it('should return hardcoded mock rates if API endpoint is set (mock)', (done) => {
+      spyOn(console, 'warn');
+      const hardcodedRates = (service as any).getHardcodedMockRates(mockRateRequest);
+      service.getShippingRates(mockRateRequest).subscribe(rates => {
+        expect(rates.length).toBe(hardcodedRates.length);
+        expect(console.warn).toHaveBeenCalledWith('FedExService: Actual API call for getShippingRates not implemented. Returning mock data.');
+        if (hardcodedRates.length > 0) {
+            expect(rates[0].serviceName).toEqual(hardcodedRates[0].serviceName);
+        }
+        done();
+      });
+      // No HTTP call expected for this path in mock implementation
+    });
+
+    it('should return hardcoded mock rates if API endpoint is NOT set (mock)', (done) => {
+        environment.fedexApiConfig.endpoint = undefined;
+        spyOn(console, 'log');
+        const hardcodedRates = (service as any).getHardcodedMockRates(mockRateRequest);
+        service.getShippingRates(mockRateRequest).subscribe(rates => {
+          expect(rates.length).toBe(hardcodedRates.length);
+          expect(console.log).toHaveBeenCalledWith('FedExService: Simulating getShippingRates (mock). Request:', mockRateRequest);
+           if (hardcodedRates.length > 0) {
+            expect(rates[0].serviceName).toEqual(hardcodedRates[0].serviceName);
+        }
+          done();
+        });
+        // No HTTP call expected
+      });
+  });
+
+  describe('createShippingLabel', () => {
+    it('should return a hardcoded mock label if API endpoint is set (mock)', (done) => {
+      spyOn(console, 'warn');
+      const hardcodedLabel = (service as any).getHardcodedMockLabel(mockLabelRequest);
+      service.createShippingLabel(mockLabelRequest).subscribe(labelResponse => {
+        expect(labelResponse?.trackingNumber).toEqual(hardcodedLabel.trackingNumber);
+        expect(console.warn).toHaveBeenCalledWith('FedExService: Actual API call for createShippingLabel not implemented. Returning mock data.');
+        done();
+      });
+    });
+    it('should return a hardcoded mock label if API endpoint is NOT set (mock)', (done) => {
+        environment.fedexApiConfig.endpoint = undefined;
+        spyOn(console, 'log');
+        const hardcodedLabel = (service as any).getHardcodedMockLabel(mockLabelRequest);
+        service.createShippingLabel(mockLabelRequest).subscribe(labelResponse => {
+          expect(labelResponse?.trackingNumber).toEqual(hardcodedLabel.trackingNumber);
+          expect(console.log).toHaveBeenCalledWith('FedExService: Simulating createShippingLabel (mock). Request:', mockLabelRequest);
+          done();
+        });
+      });
+  });
+
+  describe('trackShipment', () => {
+    it('should return hardcoded mock tracking info if API endpoint is set (mock)', (done) => {
+      spyOn(console, 'warn');
+      const hardcodedTracking = (service as any).getHardcodedMockTrackingInfo(mockTrackingRequest.trackingNumber);
+      service.trackShipment(mockTrackingRequest).subscribe(trackingResponse => {
+        expect(trackingResponse?.trackingNumber).toEqual(hardcodedTracking.trackingNumber);
+        expect(console.warn).toHaveBeenCalledWith('FedExService: Actual API call for trackShipment not implemented. Returning mock data.');
+        done();
+      });
+    });
+
+     it('should return hardcoded mock tracking info if API endpoint is NOT set (mock)', (done) => {
+        environment.fedexApiConfig.endpoint = undefined;
+        spyOn(console, 'log');
+        const hardcodedTracking = (service as any).getHardcodedMockTrackingInfo(mockTrackingRequest.trackingNumber);
+        service.trackShipment(mockTrackingRequest).subscribe(trackingResponse => {
+          expect(trackingResponse?.trackingNumber).toEqual(hardcodedTracking.trackingNumber);
+          expect(console.log).toHaveBeenCalledWith('FedExService: Simulating trackShipment (mock). Request:', mockTrackingRequest);
+          done();
+        });
+      });
+  });
+});

--- a/src/app/modules/services/fedex.service.ts
+++ b/src/app/modules/services/fedex.service.ts
@@ -1,0 +1,162 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+
+// Simplified interfaces for FedEx API data
+// These would be based on actual FedEx API request/response structures
+
+interface FedExRateRequest {
+  shipperAddress: any; // Simplified: { postalCode: string, countryCode: string }
+  recipientAddress: any; // Simplified: { postalCode: string, countryCode: string }
+  packages: Array<{
+    weight: { value: number, units: 'LB' | 'KG' };
+    dimensions?: { length: number, width: number, height: number, units: 'IN' | 'CM' };
+  }>;
+  serviceType?: string; // e.g., 'FEDEX_GROUND', 'PRIORITY_OVERNIGHT'
+  // ... other rate request details
+}
+
+interface FedExRateResponse {
+  serviceName: string;
+  totalNetCharge: number;
+  currency: string;
+  deliveryTimestamp?: string; // Estimated delivery
+  // ... other rate details
+}
+
+interface FedExLabelRequest {
+  shipper: any; // Detailed address and contact info
+  recipient: any; // Detailed address and contact info
+  serviceType: string;
+  packagingType: string; // e.g., 'YOUR_PACKAGING'
+  packages: Array<{
+    weight: { value: number, units: 'LB' | 'KG' };
+    dimensions?: { length: number, width: number, height: number, units: 'IN' | 'CM' };
+    // ... customer references, declared value etc.
+  }>;
+  labelSpecification: {
+    imageType: 'PDF' | 'PNG' | 'ZPLII';
+    labelStockType: string; // e.g., 'PAPER_4X6'
+  };
+  // ... other label request details
+}
+
+interface FedExLabelResponse {
+  trackingNumber: string;
+  labelImageBase64: string; // Base64 encoded label
+  packageDocuments?: Array<{ type: string,imageBase64: string }>; // e.g. commercial invoice
+  // ... other label details
+}
+
+interface FedExTrackingRequest {
+  trackingNumber: string;
+  // ... other tracking options
+}
+
+interface FedExTrackingResponse {
+  trackingNumber: string;
+  status: string; // e.g., "IN_TRANSIT", "DELIVERED"
+  latestEvent: {
+    timestamp: string;
+    eventDescription: string;
+    address: any; // Address of the event
+  };
+  estimatedDeliveryTimestamp?: string;
+  // ... full event history
+}
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FedExService {
+  private fedexApiEndpoint = environment.fedexApiConfig?.endpoint;
+  // Mock data URLs could be added if complex mock responses are stored in JSON files
+  // private mockRateDataUrl = environment.fedexApiConfig?.mockRateDataUrl;
+
+  constructor(private http: HttpClient) {
+    if (!this.fedexApiEndpoint) {
+      console.warn('FedExService: API endpoint is not configured in environment files.');
+    }
+  }
+
+  /**
+   * Gets shipping rates from FedEx (mock implementation).
+   * @param rateRequest - The details for the rate request.
+   * @returns An Observable stream of `FedExRateResponse[]`.
+   */
+  getShippingRates(rateRequest: FedExRateRequest): Observable<FedExRateResponse[]> {
+    if (this.fedexApiEndpoint) {
+      console.warn('FedExService: Actual API call for getShippingRates not implemented. Returning mock data.');
+      // TODO: Implement actual POST to this.fedexApiEndpoint/rates
+      // This would involve transforming rateRequest to the FedEx API structure.
+      return of(this.getHardcodedMockRates(rateRequest));
+    } else {
+      console.log('FedExService: Simulating getShippingRates (mock). Request:', rateRequest);
+      return of(this.getHardcodedMockRates(rateRequest));
+    }
+  }
+
+  /**
+   * Creates a shipping label with FedEx (mock implementation).
+   * @param labelRequest - The details for creating the label.
+   * @returns An Observable of `FedExLabelResponse`.
+   */
+  createShippingLabel(labelRequest: FedExLabelRequest): Observable<FedExLabelResponse | null> {
+    if (this.fedexApiEndpoint) {
+      console.warn('FedExService: Actual API call for createShippingLabel not implemented. Returning mock data.');
+      // TODO: Implement actual POST to this.fedexApiEndpoint/shipments (or similar)
+      return of(this.getHardcodedMockLabel(labelRequest));
+    } else {
+      console.log('FedExService: Simulating createShippingLabel (mock). Request:', labelRequest);
+      return of(this.getHardcodedMockLabel(labelRequest));
+    }
+  }
+
+  /**
+   * Tracks a shipment with FedEx (mock implementation).
+   * @param trackingRequest - The tracking number.
+   * @returns An Observable of `FedExTrackingResponse`.
+   */
+  trackShipment(trackingRequest: FedExTrackingRequest): Observable<FedExTrackingResponse | null> {
+    if (this.fedexApiEndpoint) {
+      console.warn('FedExService: Actual API call for trackShipment not implemented. Returning mock data.');
+      // TODO: Implement actual POST or GET to this.fedexApiEndpoint/track
+      return of(this.getHardcodedMockTrackingInfo(trackingRequest.trackingNumber));
+    } else {
+      console.log('FedExService: Simulating trackShipment (mock). Request:', trackingRequest);
+      return of(this.getHardcodedMockTrackingInfo(trackingRequest.trackingNumber));
+    }
+  }
+
+  private getHardcodedMockRates(request: FedExRateRequest): FedExRateResponse[] {
+    // Based on the request, one could return different mock rates
+    return [
+      { serviceName: 'FedEx Ground', totalNetCharge: 15.50, currency: 'USD', deliveryTimestamp: new Date(Date.now() + 3 * 86400000).toISOString() },
+      { serviceName: 'FedEx Priority Overnight', totalNetCharge: 45.00, currency: 'USD', deliveryTimestamp: new Date(Date.now() + 1 * 86400000).toISOString() }
+    ];
+  }
+
+  private getHardcodedMockLabel(request: FedExLabelRequest): FedExLabelResponse {
+    return {
+      trackingNumber: `FX${Date.now()}`,
+      labelImageBase64: 'UDRGMg==...', // Placeholder for actual base64 image string
+      packageDocuments: []
+    };
+  }
+
+  private getHardcodedMockTrackingInfo(trackingNumber: string): FedExTrackingResponse {
+    return {
+      trackingNumber: trackingNumber,
+      status: 'IN_TRANSIT',
+      latestEvent: {
+        timestamp: new Date().toISOString(),
+        eventDescription: 'Arrived at FedEx location',
+        address: { city: 'MEMPHIS', stateOrProvinceCode: 'TN', countryCode: 'US' }
+      },
+      estimatedDeliveryTimestamp: new Date(Date.now() + 2 * 86400000).toISOString()
+    };
+  }
+}

--- a/src/app/modules/services/quickbooks.service.spec.ts
+++ b/src/app/modules/services/quickbooks.service.spec.ts
@@ -1,0 +1,148 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { QuickBooksService } from './quickbooks.service';
+import { environment } from '../../../environments/environment';
+
+describe('QuickBooksService', () => {
+  let service: QuickBooksService;
+  let httpMock: HttpTestingController;
+
+  // Define a basic structure for RawQuickBooksInvoice for testing purposes
+  interface RawQuickBooksInvoice {
+    Id: string;
+    DocNumber?: string;
+    TotalAmt: number;
+    CustomerRef: { value: string; name?: string };
+    Line: Array<any>;
+    SyncToken: string;
+    TxnDate?: string;
+  }
+
+  const mockInvoices: RawQuickBooksInvoice[] = [
+    { Id: "1", DocNumber: "INV001", TotalAmt: 100, CustomerRef: { value: "cust1", name: "Customer 1" }, Line: [], SyncToken: "0", TxnDate: "2023-01-01" },
+    { Id: "2", DocNumber: "INV002", TotalAmt: 200, CustomerRef: { value: "cust2", name: "Customer 2" }, Line: [], SyncToken: "0", TxnDate: "2023-01-02" }
+  ];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [QuickBooksService]
+    });
+    service = TestBed.inject(QuickBooksService);
+    httpMock = TestBed.inject(HttpTestingController);
+
+    environment.quickbooksApiConfig = {
+      endpoint: 'https://mock-quickbooks-api.com',
+      mockDataUrlPrefix: '/assets/mocks/quickbooks-'
+    };
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('syncInvoices', () => {
+    it('should simulate success and log if API endpoint is set (mock)', (done) => {
+      spyOn(console, 'warn');
+      const appInvoices = [{ id: 'appInv1', amount: 150 }];
+      service.syncInvoices(appInvoices).subscribe(result => {
+        expect(result).toBe(true);
+        expect(console.warn).toHaveBeenCalledWith('QuickBooksService: Actual API call for syncInvoices not implemented. Simulating success.');
+        done();
+      });
+    });
+    it('should simulate success and log if API endpoint is NOT set (mock)', (done) => {
+      environment.quickbooksApiConfig.endpoint = undefined;
+      spyOn(console, 'log');
+      const appInvoices = [{ id: 'appInv1', amount: 150 }];
+      service.syncInvoices(appInvoices).subscribe(result => {
+        expect(result).toBe(true);
+        expect(console.log).toHaveBeenCalledWith('QuickBooksService: Simulating invoice sync (mock). Data:', appInvoices);
+        done();
+      });
+    });
+  });
+
+  describe('fetchQuickBooksInvoices', () => {
+    it('should fetch invoices from mockDataUrlPrefix if configured', (done) => {
+      service.fetchQuickBooksInvoices().subscribe(invoices => {
+        expect(invoices.length).toBe(2);
+        expect(invoices[0].Id).toBe("1");
+        done();
+      });
+      const req = httpMock.expectOne(`${environment.quickbooksApiConfig.mockDataUrlPrefix}invoices.json`);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockInvoices);
+    });
+
+    it('should return hardcoded mock invoices if mockDataUrlPrefix is not set but API endpoint is', (done) => {
+      environment.quickbooksApiConfig.mockDataUrlPrefix = undefined;
+      spyOn(console, 'warn');
+      const hardcoded = (service as any).getHardcodedMockInvoices();
+
+      service.fetchQuickBooksInvoices().subscribe(invoices => {
+        expect(invoices.length).toBe(hardcoded.length);
+        expect(console.warn).toHaveBeenCalledWith('QuickBooksService: Actual API call for fetchQuickBooksInvoices not implemented. Returning mock data.');
+        if (hardcoded.length > 0) {
+            expect(invoices[0].Id).toEqual(hardcoded[0].Id);
+        }
+        done();
+      });
+    });
+
+    it('should return hardcoded mock invoices if neither mockDataUrlPrefix nor API endpoint is set', (done) => {
+        environment.quickbooksApiConfig.mockDataUrlPrefix = undefined;
+        environment.quickbooksApiConfig.endpoint = undefined;
+        spyOn(console, 'error');
+        const hardcoded = (service as any).getHardcodedMockInvoices();
+
+        service.fetchQuickBooksInvoices().subscribe(invoices => {
+          expect(invoices.length).toBe(hardcoded.length);
+          expect(console.error).toHaveBeenCalledWith('QuickBooksService: No API endpoint or mock data URL. Returning hardcoded mock invoices.');
+           if (hardcoded.length > 0) {
+            expect(invoices[0].Id).toEqual(hardcoded[0].Id);
+          }
+          done();
+        });
+      });
+
+
+    it('should return an empty array on HTTP error when using mockDataUrlPrefix', (done) => {
+        service.fetchQuickBooksInvoices().subscribe(invoices => {
+        expect(invoices).toEqual([]);
+        done();
+      });
+      const req = httpMock.expectOne(`${environment.quickbooksApiConfig.mockDataUrlPrefix}invoices.json`);
+      req.flush('Simulated HTTP error', { status: 500, statusText: 'Server Error' });
+    });
+  });
+
+  describe('syncPayments', () => {
+    it('should simulate success and log (mock implementation)', (done) => {
+      // Similar to syncInvoices, test both cases: endpoint defined or not
+      environment.quickbooksApiConfig.endpoint = 'https://mock-quickbooks-api.com';
+      spyOn(console, 'warn');
+      service.syncPayments([{id: 'pay1'}]).subscribe(result => {
+        expect(result).toBe(true);
+        expect(console.warn).toHaveBeenCalledWith('QuickBooksService: Actual API call for syncPayments not implemented. Simulating success.');
+        done();
+      });
+    });
+  });
+
+  describe('syncCustomers', () => {
+    it('should simulate success and log (mock implementation)', (done) => {
+      environment.quickbooksApiConfig.endpoint = undefined;
+      spyOn(console, 'log');
+      service.syncCustomers([{id: 'cust1'}]).subscribe(result => {
+        expect(result).toBe(true);
+        expect(console.log).toHaveBeenCalledWith('QuickBooksService: Simulating customer sync (mock). Data:', [{id: 'cust1'}]);
+        done();
+      });
+    });
+  });
+});

--- a/src/app/modules/services/quickbooks.service.ts
+++ b/src/app/modules/services/quickbooks.service.ts
@@ -1,0 +1,155 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+// Assuming a generic Invoice model might be shared or defined here
+// For now, we'll use 'any' for simplicity for QuickBooks specific data structures
+
+// Placeholder for raw QuickBooks Invoice data
+interface RawQuickBooksInvoice {
+  Id: string;
+  SyncToken: string;
+  DocNumber?: string;
+  TxnDate?: string; // YYYY-MM-DD
+  CustomerRef: {
+    value: string; // Customer ID
+    name?: string; // Customer Name
+  };
+  Line: Array<{
+    Id?: string;
+    LineNum?: number;
+    Description?: string;
+    Amount: number;
+    DetailType: string; // e.g., "SalesItemLineDetail"
+    SalesItemLineDetail?: {
+      ItemRef: {
+        value: string; // Item ID
+        name?: string; // Item Name
+      };
+      Qty?: number;
+      UnitPrice?: number;
+    };
+  }>;
+  TotalAmt: number;
+  Balance?: number; // Remaining balance
+  // ... other QuickBooks invoice fields
+}
+
+// Placeholder for raw QuickBooks Payment data
+interface RawQuickBooksPayment {
+  Id: string;
+  SyncToken: string;
+  TxnDate?: string;
+  CustomerRef: {
+    value: string;
+    name?: string;
+  };
+  TotalAmt: number;
+  // ... other QuickBooks payment fields
+}
+
+// Placeholder for raw QuickBooks Customer data
+interface RawQuickBooksCustomer {
+  Id: string;
+  SyncToken: string;
+  DisplayName?: string;
+  PrimaryEmailAddr?: {
+    Address: string;
+  };
+  BillAddr?: {
+    Line1?: string;
+    City?: string;
+    CountrySubDivisionCode?: string; // State/Province
+    PostalCode?: string;
+    Country?: string;
+  };
+  // ... other QuickBooks customer fields
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class QuickBooksService {
+  private quickBooksApiEndpoint = environment.quickbooksApiConfig?.endpoint;
+  private mockDataUrlPrefix = environment.quickbooksApiConfig?.mockDataUrlPrefix; // e.g., /assets/mocks/quickbooks-
+
+  constructor(private http: HttpClient) {
+    if (!this.quickBooksApiEndpoint && !this.mockDataUrlPrefix) {
+      console.warn('QuickBooksService: API endpoint or mockDataUrlPrefix is not configured.');
+    }
+  }
+
+  // --- Invoice Synchronization ---
+  syncInvoices(invoices: any[] /* Replace 'any' with your app's Invoice model */): Observable<boolean> {
+    if (this.quickBooksApiEndpoint) {
+      console.warn('QuickBooksService: Actual API call for syncInvoices not implemented. Simulating success.');
+      // TODO: Implement actual POST/PUT to this.quickBooksApiEndpoint/invoice
+      // This would likely involve transforming your app's invoice model to RawQuickBooksInvoice
+      return of(true);
+    } else {
+      console.log('QuickBooksService: Simulating invoice sync (mock). Data:', invoices);
+      return of(true);
+    }
+  }
+
+  fetchQuickBooksInvoices(): Observable<RawQuickBooksInvoice[]> {
+    if (this.mockDataUrlPrefix) {
+      return this.http.get<RawQuickBooksInvoice[]>(`${this.mockDataUrlPrefix}invoices.json`).pipe(
+        catchError(err => {
+          console.error('Error fetching mock QuickBooks invoices:', err);
+          return of([]);
+        })
+      );
+    } else if (this.quickBooksApiEndpoint) {
+      console.warn('QuickBooksService: Actual API call for fetchQuickBooksInvoices not implemented. Returning mock data.');
+      // TODO: Implement actual GET from this.quickBooksApiEndpoint/query?query=SELECT * FROM Invoice
+      return of(this.getHardcodedMockInvoices());
+    } else {
+      console.error('QuickBooksService: No API endpoint or mock data URL. Returning hardcoded mock invoices.');
+      return of(this.getHardcodedMockInvoices());
+    }
+  }
+
+  // --- Payment Synchronization ---
+  syncPayments(payments: any[] /* Replace 'any' with your app's Payment model */): Observable<boolean> {
+    if (this.quickBooksApiEndpoint) {
+      console.warn('QuickBooksService: Actual API call for syncPayments not implemented. Simulating success.');
+      // TODO: Implement actual POST/PUT to this.quickBooksApiEndpoint/payment
+      return of(true);
+    } else {
+      console.log('QuickBooksService: Simulating payment sync (mock). Data:', payments);
+      return of(true);
+    }
+  }
+
+  // --- Customer Data Synchronization ---
+  syncCustomers(customers: any[] /* Replace 'any' with your app's Customer model */): Observable<boolean> {
+    if (this.quickBooksApiEndpoint) {
+      console.warn('QuickBooksService: Actual API call for syncCustomers not implemented. Simulating success.');
+      // TODO: Implement actual POST/PUT to this.quickBooksApiEndpoint/customer
+      return of(true);
+    } else {
+      console.log('QuickBooksService: Simulating customer sync (mock). Data:', customers);
+      return of(true);
+    }
+  }
+
+  private getHardcodedMockInvoices(): RawQuickBooksInvoice[] {
+    return [
+      {
+        Id: "1", SyncToken: "0", DocNumber: "INV001", TxnDate: "2023-01-15",
+        CustomerRef: { value: "101", name: "Customer A" },
+        Line: [{ Amount: 100, DetailType: "SalesItemLineDetail", SalesItemLineDetail: { ItemRef: { value: "ITEM01", name: "Product 1" }, Qty: 1, UnitPrice: 100 } }],
+        TotalAmt: 100
+      },
+      {
+        Id: "2", SyncToken: "0", DocNumber: "INV002", TxnDate: "2023-01-20",
+        CustomerRef: { value: "102", name: "Customer B" },
+        Line: [{ Amount: 250, DetailType: "SalesItemLineDetail", SalesItemLineDetail: { ItemRef: { value: "ITEM02", name: "Service X" }, Qty: 5, UnitPrice: 50 } }],
+        TotalAmt: 250, Balance: 50
+      }
+    ];
+  }
+  // Add similar getHardcodedMockPayments, getHardcodedMockCustomers if needed for fetching from QuickBooks
+}

--- a/src/app/modules/services/shippo.service.spec.ts
+++ b/src/app/modules/services/shippo.service.spec.ts
@@ -1,0 +1,112 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ShippoService } from './shippo.service';
+import { environment } from '../../../environments/environment';
+
+// Simplified interfaces for testing
+interface ShippoAddress { name: string; street1: string; city: string; state: string; zip: string; country: string; }
+interface ShippoParcel { length: string; width: string; height: string; distance_unit: 'cm' | 'in'; weight: string; mass_unit: 'g' | 'oz' | 'lb' | 'kg'; }
+interface ShippoShipmentRequest { address_from: ShippoAddress; address_to: ShippoAddress; parcels: ShippoParcel[]; }
+interface ShippoTransactionRequest { rate: string; label_file_type?: 'PDF' | 'PNG' | 'PDF_4x6' | 'ZPLII'; }
+interface ShippoTrackRequest { carrier: string; tracking_number: string; }
+
+describe('ShippoService', () => {
+  let service: ShippoService;
+  let httpMock: HttpTestingController;
+
+  const mockAddressFrom: ShippoAddress = { name: 'From', street1: '1 St', city: 'CityA', state: 'CA', zip: '10000', country: 'US' };
+  const mockAddressTo: ShippoAddress = { name: 'To', street1: '2 St', city: 'CityB', state: 'NY', zip: '20000', country: 'US' };
+  const mockParcel: ShippoParcel = { length: '10', width: '10', height: '10', distance_unit: 'in', weight: '1', mass_unit: 'lb' };
+  const mockShipmentRequest: ShippoShipmentRequest = { address_from: mockAddressFrom, address_to: mockAddressTo, parcels: [mockParcel] };
+  const mockTransactionRequest: ShippoTransactionRequest = { rate: 'rate_mock_id_123', label_file_type: 'PNG' };
+  const mockTrackRequest: ShippoTrackRequest = { carrier: 'fedex', tracking_number: 'track123' };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ShippoService]
+    });
+    service = TestBed.inject(ShippoService);
+    httpMock = TestBed.inject(HttpTestingController);
+
+    environment.shippoApiConfig = { // Ensure this is defined
+      endpoint: 'https://api.goshippo.com/mock/' // Mock endpoint
+    };
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('createShipmentAndGetRates', () => {
+    it('should return hardcoded mock rates if API endpoint is set (mock)', (done) => {
+      spyOn(console, 'warn');
+      const hardcodedRates = (service as any).getHardcodedMockRates(mockShipmentRequest);
+      service.createShipmentAndGetRates(mockShipmentRequest).subscribe(rates => {
+        expect(rates.length).toEqual(hardcodedRates.length);
+        expect(console.warn).toHaveBeenCalledWith('ShippoService: Actual API call for createShipmentAndGetRates not implemented. Returning mock data.');
+        if(hardcodedRates.length > 0) expect(rates[0].provider).toEqual(hardcodedRates[0].provider);
+        done();
+      });
+    });
+     it('should return hardcoded mock rates if API endpoint is NOT set (mock)', (done) => {
+        environment.shippoApiConfig.endpoint = undefined;
+        spyOn(console, 'log');
+        const hardcodedRates = (service as any).getHardcodedMockRates(mockShipmentRequest);
+        service.createShipmentAndGetRates(mockShipmentRequest).subscribe(rates => {
+          expect(rates.length).toEqual(hardcodedRates.length);
+          expect(console.log).toHaveBeenCalledWith('ShippoService: Simulating createShipmentAndGetRates (mock). Request:', mockShipmentRequest);
+          if(hardcodedRates.length > 0) expect(rates[0].provider).toEqual(hardcodedRates[0].provider);
+          done();
+        });
+      });
+  });
+
+  describe('createShippingLabel', () => {
+    it('should return a hardcoded mock transaction if API endpoint is set (mock)', (done) => {
+      spyOn(console, 'warn');
+      const hardcodedTransaction = (service as any).getHardcodedMockTransaction(mockTransactionRequest);
+      service.createShippingLabel(mockTransactionRequest).subscribe(transaction => {
+        expect(transaction?.tracking_number).toEqual(hardcodedTransaction.tracking_number);
+        expect(console.warn).toHaveBeenCalledWith('ShippoService: Actual API call for createShippingLabel (transaction) not implemented. Returning mock data.');
+        done();
+      });
+    });
+    it('should return a hardcoded mock transaction if API endpoint is NOT set (mock)', (done) => {
+        environment.shippoApiConfig.endpoint = undefined;
+        spyOn(console, 'log');
+        const hardcodedTransaction = (service as any).getHardcodedMockTransaction(mockTransactionRequest);
+        service.createShippingLabel(mockTransactionRequest).subscribe(transaction => {
+          expect(transaction?.tracking_number).toEqual(hardcodedTransaction.tracking_number);
+          expect(console.log).toHaveBeenCalledWith('ShippoService: Simulating createShippingLabel (mock). Request:', mockTransactionRequest);
+          done();
+        });
+      });
+  });
+
+  describe('trackShipment', () => {
+    it('should return hardcoded mock tracking info if API endpoint is set (mock)', (done) => {
+      spyOn(console, 'warn');
+      const hardcodedTrack = (service as any).getHardcodedMockTrackingInfo(mockTrackRequest);
+      service.trackShipment(mockTrackRequest).subscribe(trackInfo => {
+        expect(trackInfo?.tracking_number).toEqual(hardcodedTrack.tracking_number);
+        expect(console.warn).toHaveBeenCalledWith('ShippoService: Actual API call for trackShipment not implemented. Returning mock data.');
+        done();
+      });
+    });
+    it('should return hardcoded mock tracking info if API endpoint is NOT set (mock)', (done) => {
+        environment.shippoApiConfig.endpoint = undefined;
+        spyOn(console, 'log');
+        const hardcodedTrack = (service as any).getHardcodedMockTrackingInfo(mockTrackRequest);
+        service.trackShipment(mockTrackRequest).subscribe(trackInfo => {
+          expect(trackInfo?.tracking_number).toEqual(hardcodedTrack.tracking_number);
+          expect(console.log).toHaveBeenCalledWith('ShippoService: Simulating trackShipment (mock). Request:', mockTrackRequest);
+          done();
+        });
+      });
+  });
+});

--- a/src/app/modules/services/shippo.service.ts
+++ b/src/app/modules/services/shippo.service.ts
@@ -1,0 +1,206 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+
+// Simplified interfaces for Shippo API data
+// Based on common Shippo API functionalities (Addresses, Parcels, Shipments, Rates, Transactions, Tracks)
+
+interface ShippoAddress {
+  name: string;
+  street1: string;
+  street2?: string;
+  city: string;
+  state: string; // State/Province code (e.g., "CA")
+  zip: string;
+  country: string; // ISO 3166-1 alpha-2 country code (e.g., "US")
+  phone?: string;
+  email?: string;
+  is_residential?: boolean;
+  // validate?: boolean; // To request address validation
+}
+
+interface ShippoParcel {
+  length: string; // cm, in
+  width: string;
+  height: string;
+  distance_unit: 'cm' | 'in';
+  weight: string; // g, oz, lb, kg
+  mass_unit: 'g' | 'oz' | 'lb' | 'kg';
+  template?: string; // e.g., "FedEx_Box_10kg"
+  // metadata?: string;
+}
+
+interface ShippoShipmentRequest {
+  address_from: ShippoAddress | string; // Can be an object_id or an address object
+  address_to: ShippoAddress | string;
+  parcels: ShippoParcel[] | string[]; // Array of object_ids or parcel objects
+  // customs_declaration?: any; // For international
+  // carrier_accounts?: string[]; // Specific accounts to use
+  async?: boolean; // Default true for rates
+}
+
+interface ShippoRate {
+  object_id: string;
+  amount: string; // e.g., "7.54"
+  currency: string; // e.g., "USD"
+  provider: string; // e.g., "FedEx"
+  provider_image_75: string; // URL
+  provider_image_200: string; // URL
+  servicelevel: {
+    token: string; // e.g., "fedex_ground"
+    name: string; // e.g., "FedEx Ground"
+  };
+  estimated_days: number;
+  duration_terms: string; // e.g. "Delivery in 3 business days"
+  // attributes: string[]; // e.g. "CHEAPEST", "BESTVALUE", "FASTEST"
+  // ... other fields like messages, zone
+}
+
+interface ShippoTransactionRequest {
+  rate: string; // object_id of the selected rate
+  label_file_type?: 'PDF' | 'PNG' | 'PDF_4x6' | 'ZPLII'; // Default PDF_4x6
+  async?: boolean;
+}
+
+interface ShippoTransaction {
+  object_id: string;
+  status: 'QUEUED' | 'WAITING' | 'SUCCESS' | 'ERROR' | 'REFUNDED' | 'REFUNDPENDING' | 'REFUNDREJECTED';
+  rate: string; // Rate object_id
+  tracking_number: string;
+  tracking_url_provider: string; // Link to carrier's tracking page
+  label_url: string; // Link to download the label
+  commercial_invoice_url?: string;
+  messages?: Array<{text: string}>;
+  // eta?: string; // ISO 8601
+  // ... other fields
+}
+
+interface ShippoTrackRequest {
+  carrier: string; // e.g., "fedex", "ups", "usps" (Shippo carrier token)
+  tracking_number: string;
+}
+
+interface ShippoTrack {
+  carrier: string;
+  tracking_number: string;
+  address_from?: ShippoAddress;
+  address_to?: ShippoAddress;
+  eta?: string; // ISO 8601
+  original_eta?: string;
+  servicelevel?: { token: string, name: string };
+  tracking_status?: {
+    status: 'PRE_TRANSIT' | 'TRANSIT' | 'DELIVERED' | 'RETURNED' | 'FAILURE' | 'UNKNOWN';
+    status_details: string;
+    status_date: string; // ISO 8601
+    location?: any; // Simplified address object
+  };
+  tracking_history?: Array<{ // Most recent first
+    status: string; // As above
+    status_details: string;
+    status_date: string;
+    location?: any;
+  }>;
+  // messages?: any[];
+}
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ShippoService {
+  private shippoApiEndpoint = environment.shippoApiConfig?.endpoint; // e.g., https://api.goshippo.com/
+  // Mock data URLs if needed, e.g., for a complex rate list
+
+  constructor(private http: HttpClient) {
+    if (!this.shippoApiEndpoint) {
+      console.warn('ShippoService: API endpoint is not configured in environment files. Mock mode only.');
+    }
+  }
+
+  // In Shippo, you typically create a Shipment object first, then its rates are retrieved.
+  createShipmentAndGetRates(shipmentRequest: ShippoShipmentRequest): Observable<ShippoRate[]> {
+    if (this.shippoApiEndpoint) {
+      console.warn('ShippoService: Actual API call for createShipmentAndGetRates not implemented. Returning mock data.');
+      // TODO: Implement actual POST to this.shippoApiEndpoint/shipments/
+      // The response from Shippo for a shipment creation will contain the rates array.
+      // This mock simplifies by directly returning rates.
+      return of(this.getHardcodedMockRates(shipmentRequest));
+    } else {
+      console.log('ShippoService: Simulating createShipmentAndGetRates (mock). Request:', shipmentRequest);
+      return of(this.getHardcodedMockRates(shipmentRequest));
+    }
+  }
+
+  createShippingLabel(transactionRequest: ShippoTransactionRequest): Observable<ShippoTransaction | null> {
+    if (this.shippoApiEndpoint) {
+      console.warn('ShippoService: Actual API call for createShippingLabel (transaction) not implemented. Returning mock data.');
+      // TODO: Implement actual POST to this.shippoApiEndpoint/transactions/
+      return of(this.getHardcodedMockTransaction(transactionRequest));
+    } else {
+      console.log('ShippoService: Simulating createShippingLabel (mock). Request:', transactionRequest);
+      return of(this.getHardcodedMockTransaction(transactionRequest));
+    }
+  }
+
+  // Shippo uses a specific endpoint for tracking, not per carrier.
+  trackShipment(trackRequest: ShippoTrackRequest): Observable<ShippoTrack | null> {
+    if (this.shippoApiEndpoint) {
+      console.warn('ShippoService: Actual API call for trackShipment not implemented. Returning mock data.');
+      // TODO: Implement actual GET to this.shippoApiEndpoint/tracks/{carrier}/{tracking_number}/
+      return of(this.getHardcodedMockTrackingInfo(trackRequest));
+    } else {
+      console.log('ShippoService: Simulating trackShipment (mock). Request:', trackRequest);
+      return of(this.getHardcodedMockTrackingInfo(trackRequest));
+    }
+  }
+
+  private getHardcodedMockRates(request: ShippoShipmentRequest): ShippoRate[] {
+    // Mock rates from various carriers
+    return [
+      { object_id: 'rate_mock_fedex_ground', amount: '10.25', currency: 'USD', provider: 'FedEx', provider_image_75: '', provider_image_200: '', servicelevel: { token: 'fedex_ground', name: 'FedEx Ground' }, estimated_days: 3, duration_terms: 'Est. 3 business days' },
+      { object_id: 'rate_mock_ups_ground', amount: '11.50', currency: 'USD', provider: 'UPS', provider_image_75: '', provider_image_200: '', servicelevel: { token: 'ups_ground', name: 'UPS Ground' }, estimated_days: 3, duration_terms: 'Est. 3 business days' },
+      { object_id: 'rate_mock_usps_priority', amount: '9.80', currency: 'USD', provider: 'USPS', provider_image_75: '', provider_image_200: '', servicelevel: { token: 'usps_priority', name: 'USPS Priority Mail' }, estimated_days: 2, duration_terms: 'Est. 2 business days' },
+      { object_id: 'rate_mock_dhl_express', amount: '25.00', currency: 'USD', provider: 'DHL Express', provider_image_75: '', provider_image_200: '', servicelevel: { token: 'dhl_express_worldwide', name: 'DHL Express Worldwide' }, estimated_days: 1, duration_terms: 'Est. 1 business day' }
+    ];
+  }
+
+  private getHardcodedMockTransaction(request: ShippoTransactionRequest): ShippoTransaction {
+    const selectedRateId = request.rate;
+    let carrier = 'unknown';
+    if (selectedRateId.includes('fedex')) carrier = 'FedEx';
+    else if (selectedRateId.includes('ups')) carrier = 'UPS';
+    else if (selectedRateId.includes('usps')) carrier = 'USPS';
+    else if (selectedRateId.includes('dhl')) carrier = 'DHL';
+
+    return {
+      object_id: `txn_mock_${Date.now()}`,
+      status: 'SUCCESS',
+      rate: selectedRateId,
+      tracking_number: `${carrier.toUpperCase()}_TRACK_${Date.now()}`,
+      tracking_url_provider: `https://www.tracking.example.com/${carrier}/?tn=${Date.now()}`, // Placeholder
+      label_url: 'https://api.goshippo.com/mocklabel.pdf', // Placeholder
+      messages: [{text: 'Mock label generated successfully.'}]
+    };
+  }
+
+  private getHardcodedMockTrackingInfo(request: ShippoTrackRequest): ShippoTrack {
+    const now = new Date().toISOString();
+    return {
+      carrier: request.carrier,
+      tracking_number: request.tracking_number,
+      tracking_status: {
+        status: 'TRANSIT',
+        status_details: 'Package is on its way to the destination.',
+        status_date: now,
+        location: { city: 'CHICAGO', state: 'IL', zip: '60607', country: 'US' }
+      },
+      eta: new Date(Date.now() + 2 * 86400000).toISOString(), // 2 days from now
+      tracking_history: [
+        { status: 'TRANSIT', status_details: 'Arrived at sort facility.', status_date: now, location: { city: 'CHICAGO', state: 'IL', zip: '60607', country: 'US' } },
+        { status: 'TRANSIT', status_details: 'Departed from origin.', status_date: new Date(Date.now() - 86400000).toISOString(), location: { city: 'LOS ANGELES', state: 'CA', zip: '90001', country: 'US' } }
+      ]
+    };
+  }
+}

--- a/src/app/modules/services/ups.service.spec.ts
+++ b/src/app/modules/services/ups.service.spec.ts
@@ -1,0 +1,135 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { UPSService } from './ups.service';
+import { environment } from '../../../environments/environment';
+
+// Define simplified interfaces for testing as used in the service
+interface UPSRateRequest {
+  shipper: { address: any }; shipTo: { address: any };
+  package: {
+    packageWeight: { Weight: string; UnitOfMeasurement: { Code: 'LBS' | 'KGS' } };
+    packagingType?: { Code: string };
+  };
+}
+
+interface UPSLabelRequest {
+  shipmentRequest: { shipment: {
+    shipper: any; shipTo: any; service: { Code: string };
+    package: any; labelSpecification: { LabelImageFormat: { Code: string } };
+  }};
+}
+
+interface UPSTrackingRequest {
+  trackingNumber: string;
+}
+
+describe('UPSService', () => {
+  let service: UPSService;
+  let httpMock: HttpTestingController;
+
+  const mockRateRequest: UPSRateRequest = {
+    shipper: { address: { PostalCode: '90210', CountryCode: 'US' } },
+    shipTo: { address: { PostalCode: '10001', CountryCode: 'US' } },
+    package: { packageWeight: { Weight: '5', UnitOfMeasurement: { Code: 'LBS' } }, packagingType: { Code: '02' } }
+  };
+
+  const mockLabelRequest: UPSLabelRequest = {
+    shipmentRequest: { shipment: {
+      shipper: { Name: 'Test Shipper' }, shipTo: { Name: 'Test Recipient' },
+      service: { Code: '03' }, // UPS Ground
+      package: { packageWeight: { Weight: '5', UnitOfMeasurement: { Code: 'LBS' } } },
+      labelSpecification: { LabelImageFormat: { Code: 'PNG' } }
+    }}
+  };
+
+  const mockTrackingRequest: UPSTrackingRequest = { trackingNumber: '1Z12345E0205271688' };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [UPSService]
+    });
+    service = TestBed.inject(UPSService);
+    httpMock = TestBed.inject(HttpTestingController);
+
+    environment.upsApiConfig = { // Ensure this is defined for tests
+      endpoint: 'https://mock-ups-api.com'
+    };
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getShippingRates', () => {
+    it('should return hardcoded mock rates if API endpoint is set (mock)', (done) => {
+      spyOn(console, 'warn');
+      const hardcodedRates = (service as any).getHardcodedMockRates(mockRateRequest);
+      service.getShippingRates(mockRateRequest).subscribe(rates => {
+        expect(rates.length).toBe(hardcodedRates.length);
+        expect(console.warn).toHaveBeenCalledWith('UPSService: Actual API call for getShippingRates not implemented. Returning mock data.');
+        if(hardcodedRates.length > 0) expect(rates[0].service.Code).toEqual(hardcodedRates[0].service.Code);
+        done();
+      });
+    });
+     it('should return hardcoded mock rates if API endpoint is NOT set (mock)', (done) => {
+        environment.upsApiConfig.endpoint = undefined;
+        spyOn(console, 'log');
+        const hardcodedRates = (service as any).getHardcodedMockRates(mockRateRequest);
+        service.getShippingRates(mockRateRequest).subscribe(rates => {
+          expect(rates.length).toBe(hardcodedRates.length);
+          expect(console.log).toHaveBeenCalledWith('UPSService: Simulating getShippingRates (mock). Request:', mockRateRequest);
+          if(hardcodedRates.length > 0) expect(rates[0].service.Code).toEqual(hardcodedRates[0].service.Code);
+          done();
+        });
+      });
+  });
+
+  describe('createShippingLabel', () => {
+    it('should return a hardcoded mock label if API endpoint is set (mock)', (done) => {
+      spyOn(console, 'warn');
+      const hardcodedLabel = (service as any).getHardcodedMockLabel(mockLabelRequest);
+      service.createShippingLabel(mockLabelRequest).subscribe(labelResponse => {
+        expect(labelResponse?.shipmentResponse.shipmentResults.trackingNumber).toEqual(hardcodedLabel.shipmentResponse.shipmentResults.trackingNumber);
+        expect(console.warn).toHaveBeenCalledWith('UPSService: Actual API call for createShippingLabel not implemented. Returning mock data.');
+        done();
+      });
+    });
+     it('should return a hardcoded mock label if API endpoint is NOT set (mock)', (done) => {
+        environment.upsApiConfig.endpoint = undefined;
+        spyOn(console, 'log');
+        const hardcodedLabel = (service as any).getHardcodedMockLabel(mockLabelRequest);
+        service.createShippingLabel(mockLabelRequest).subscribe(labelResponse => {
+          expect(labelResponse?.shipmentResponse.shipmentResults.trackingNumber).toEqual(hardcodedLabel.shipmentResponse.shipmentResults.trackingNumber);
+          expect(console.log).toHaveBeenCalledWith('UPSService: Simulating createShippingLabel (mock). Request:', mockLabelRequest);
+          done();
+        });
+      });
+  });
+
+  describe('trackShipment', () => {
+    it('should return hardcoded mock tracking info if API endpoint is set (mock)', (done) => {
+      spyOn(console, 'warn');
+      const hardcodedTracking = (service as any).getHardcodedMockTrackingInfo(mockTrackingRequest.trackingNumber);
+      service.trackShipment(mockTrackingRequest).subscribe(trackingResponse => {
+        expect(trackingResponse?.shipment[0].package[0].trackingNumber).toEqual(hardcodedTracking.shipment[0].package[0].trackingNumber);
+        expect(console.warn).toHaveBeenCalledWith('UPSService: Actual API call for trackShipment not implemented. Returning mock data.');
+        done();
+      });
+    });
+    it('should return hardcoded mock tracking info if API endpoint is NOT set (mock)', (done) => {
+        environment.upsApiConfig.endpoint = undefined;
+        spyOn(console, 'log');
+        const hardcodedTracking = (service as any).getHardcodedMockTrackingInfo(mockTrackingRequest.trackingNumber);
+        service.trackShipment(mockTrackingRequest).subscribe(trackingResponse => {
+          expect(trackingResponse?.shipment[0].package[0].trackingNumber).toEqual(hardcodedTracking.shipment[0].package[0].trackingNumber);
+          expect(console.log).toHaveBeenCalledWith('UPSService: Simulating trackShipment (mock). Request:', mockTrackingRequest);
+          done();
+        });
+      });
+  });
+});

--- a/src/app/modules/services/ups.service.ts
+++ b/src/app/modules/services/ups.service.ts
@@ -1,0 +1,185 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+
+// Simplified interfaces for UPS API data
+// Based on common functionalities of UPS APIs (Rating, Shipping, Tracking)
+
+interface UPSRateRequest {
+  shipper: { address: any }; // Simplified: { PostalCode: string, CountryCode: string }
+  shipTo: { address: any }; // Simplified: { PostalCode: string, CountryCode: string }
+  package: {
+    packagingType?: { Code: string }; // e.g., "02" for customer supplied
+    packageWeight: {
+      Weight: string; // e.g., "5"
+      UnitOfMeasurement: { Code: 'LBS' | 'KGS' };
+    };
+    dimensions?: { // Optional
+      Length: string;
+      Width: string;
+      Height: string;
+      UnitOfMeasurement: { Code: 'IN' | 'CM' };
+    };
+  };
+  service?: { Code: string }; // e.g., "03" for Ground, "01" for Next Day Air
+  // ... other details like shipment total weight, number of packages
+}
+
+interface UPSRateResponse {
+  service: { Code: string, Description?: string };
+  totalCharges: { MonetaryValue: string, CurrencyCode: string };
+  estimatedDelivery?: { date: string, time?: string }; // Simplified
+  // ... other details like guaranteed days to delivery
+}
+
+interface UPSLabelRequest {
+  shipmentRequest: {
+    shipment: {
+      shipper: any; // Detailed address, contact, shipper number
+      shipTo: any; // Detailed address, contact
+      service: { Code: string }; // e.g., "03"
+      package: any; // Similar to rate request package, plus declared value etc.
+      paymentInformation?: any; // Shipper account or third party
+      labelSpecification: {
+        LabelImageFormat: { Code: 'GIF' | 'PNG' | 'PDF' | 'ZPL' | 'EPL2' };
+        LabelStockSize?: { Height: string, Width: string }; // e.g. 4x6
+      };
+    };
+  };
+}
+
+interface UPSLabelResponse {
+  shipmentResponse: {
+    shipmentResults: {
+      trackingNumber: string;
+      packageResults: {
+        shippingLabel: {
+          ImageFormat: { Code: string };
+          GraphicImage: string; // Base64 encoded label
+        };
+        // ... other documents like receipts, forms
+      };
+    };
+  };
+}
+
+interface UPSTrackingRequest {
+  trackingNumber: string;
+  // inquiryOption?: 'allstatus' | 'laststatus';
+}
+
+interface UPSTrackingResponse {
+  shipment: [{
+    package: [{
+      trackingNumber: string;
+      activity: Array<{ // Array of tracking events
+        status: { Type: string, Description: string, Code?: string }; // e.g., "I" for In Transit, "D" for Delivered
+        date: string; // YYYYMMDD
+        time: string; // HHMMSS
+        location?: { address: any };
+      }>;
+      deliveryDate?: [{ // If delivered
+          type: string; // e.g., "DEL"
+          date: string; // YYYYMMDD
+      }];
+      deliveryTime?: { // If delivered
+          type: string; // e.g., "DEL"
+          startTime?: string; // HHMMSS
+          endTime?: string; // HHMMSS
+      };
+    }];
+  }];
+}
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UPSService {
+  private upsApiEndpoint = environment.upsApiConfig?.endpoint;
+  // Mock data URLs could be added here
+
+  constructor(private http: HttpClient) {
+    if (!this.upsApiEndpoint) {
+      console.warn('UPSService: API endpoint is not configured in environment files.');
+    }
+  }
+
+  getShippingRates(rateRequest: UPSRateRequest): Observable<UPSRateResponse[]> {
+    if (this.upsApiEndpoint) {
+      console.warn('UPSService: Actual API call for getShippingRates not implemented. Returning mock data.');
+      // TODO: Implement actual POST to this.upsApiEndpoint/rating/Rate (or similar, depends on API version)
+      return of(this.getHardcodedMockRates(rateRequest));
+    } else {
+      console.log('UPSService: Simulating getShippingRates (mock). Request:', rateRequest);
+      return of(this.getHardcodedMockRates(rateRequest));
+    }
+  }
+
+  createShippingLabel(labelRequest: UPSLabelRequest): Observable<UPSLabelResponse | null> {
+    if (this.upsApiEndpoint) {
+      console.warn('UPSService: Actual API call for createShippingLabel not implemented. Returning mock data.');
+      // TODO: Implement actual POST to this.upsApiEndpoint/shipping/Ship (or similar)
+      return of(this.getHardcodedMockLabel(labelRequest));
+    } else {
+      console.log('UPSService: Simulating createShippingLabel (mock). Request:', labelRequest);
+      return of(this.getHardcodedMockLabel(labelRequest));
+    }
+  }
+
+  trackShipment(trackingRequest: UPSTrackingRequest): Observable<UPSTrackingResponse | null> {
+    if (this.upsApiEndpoint) {
+      console.warn('UPSService: Actual API call for trackShipment not implemented. Returning mock data.');
+      // TODO: Implement actual GET or POST to this.upsApiEndpoint/tracking/Track (or similar)
+      return of(this.getHardcodedMockTrackingInfo(trackingRequest.trackingNumber));
+    } else {
+      console.log('UPSService: Simulating trackShipment (mock). Request:', trackingRequest);
+      return of(this.getHardcodedMockTrackingInfo(trackingRequest.trackingNumber));
+    }
+  }
+
+  private getHardcodedMockRates(request: UPSRateRequest): UPSRateResponse[] {
+    return [
+      { service: { Code: '03', Description: 'UPS Ground' }, totalCharges: { MonetaryValue: '12.75', CurrencyCode: 'USD' }, estimatedDelivery: { date: '20231028' } },
+      { service: { Code: '01', Description: 'UPS Next Day Air' }, totalCharges: { MonetaryValue: '38.50', CurrencyCode: 'USD' }, estimatedDelivery: { date: '20231026', time: '103000' } }
+    ];
+  }
+
+  private getHardcodedMockLabel(request: UPSLabelRequest): UPSLabelResponse {
+    const trackingNum = `1Z${Math.random().toString().slice(2, 18).toUpperCase()}`;
+    return {
+      shipmentResponse: {
+        shipmentResults: {
+          trackingNumber: trackingNum,
+          packageResults: {
+            shippingLabel: {
+              ImageFormat: { Code: request.shipmentRequest.shipment.labelSpecification.LabelImageFormat.Code },
+              GraphicImage: 'R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=' // Placeholder for actual base64 image (1x1 black pixel GIF)
+            }
+          }
+        }
+      }
+    };
+  }
+
+  private getHardcodedMockTrackingInfo(trackingNumber: string): UPSTrackingResponse {
+    const today = new Date();
+    const yyyymmdd = today.toISOString().slice(0,10).replace(/-/g, '');
+    return {
+      shipment: [{
+        package: [{
+          trackingNumber: trackingNumber,
+          activity: [
+            { status: { Type: 'I', Description: 'In Transit: On its way to a UPS facility', Code: 'IX' }, date: yyyymmdd, time: '100000', location: { address: { City: 'LOUISVILLE', StateProvinceCode: 'KY', CountryCode: 'US' } } },
+            { status: { Type: 'O', Description: 'Origin Scan', Code: 'OR' }, date: yyyymmdd, time: '080000', location: { address: { City: 'SOMEWHERE', StateProvinceCode: 'CA', CountryCode: 'US' } } }
+          ],
+          // Example for delivered:
+          // deliveryDate: [{ type: "DEL", date: "20231025" }],
+          // deliveryTime: { type: "DEL", startTime: "143000" }
+        }]
+      }]
+    };
+  }
+}

--- a/src/app/modules/services/xero.service.spec.ts
+++ b/src/app/modules/services/xero.service.spec.ts
@@ -1,0 +1,157 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { XeroService } from './xero.service';
+import { environment } from '../../../environments/environment';
+
+describe('XeroService', () => {
+  let service: XeroService;
+  let httpMock: HttpTestingController;
+
+  interface RawXeroInvoice { // Basic structure for testing
+    InvoiceID?: string;
+    InvoiceNumber?: string;
+    Type: 'ACCREC' | 'ACCPAY';
+    Contact: { Name?: string };
+    Total?: number;
+    Status?: string;
+  }
+
+  const mockXeroInvoicesResponse = { // Xero often wraps arrays
+    Invoices: [
+      { InvoiceID: "x1", InvoiceNumber: "XINV001", Type: "ACCREC", Contact: { Name: "Customer X1" }, Total: 150, Status: "AUTHORISED" },
+      { InvoiceID: "x2", InvoiceNumber: "XINV002", Type: "ACCREC", Contact: { Name: "Customer X2" }, Total: 250, Status: "PAID" }
+    ]
+  };
+  const mockXeroInvoicesArray: RawXeroInvoice[] = mockXeroInvoicesResponse.Invoices;
+
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [XeroService]
+    });
+    service = TestBed.inject(XeroService);
+    httpMock = TestBed.inject(HttpTestingController);
+
+    environment.xeroApiConfig = {
+      endpoint: 'https://mock-xero-api.com',
+      mockDataUrlPrefix: '/assets/mocks/xero-'
+    };
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('syncInvoicesToXero', () => {
+    it('should simulate success and log if API endpoint is set (mock)', (done) => {
+      spyOn(console, 'warn');
+      service.syncInvoicesToXero([{ id: 'appInv1' }]).subscribe(result => {
+        expect(result).toBe(true);
+        expect(console.warn).toHaveBeenCalledWith('XeroService: Actual API call for syncInvoicesToXero not implemented. Simulating success.');
+        done();
+      });
+    });
+    it('should simulate success and log if API endpoint is NOT set (mock)', (done) => {
+      environment.xeroApiConfig.endpoint = undefined;
+      spyOn(console, 'log');
+      const appInvoices = [{ id: 'appInv1' }];
+      service.syncInvoicesToXero(appInvoices).subscribe(result => {
+        expect(result).toBe(true);
+        expect(console.log).toHaveBeenCalledWith('XeroService: Simulating invoice sync to Xero (mock). Data:', appInvoices);
+        done();
+      });
+    });
+  });
+
+  describe('fetchInvoicesFromXero', () => {
+    it('should fetch invoices from mockDataUrlPrefix if configured', (done) => {
+      service.fetchInvoicesFromXero().subscribe(invoices => {
+        expect(invoices.length).toBe(2);
+        expect(invoices[0].InvoiceID).toBe("x1");
+        done();
+      });
+      const req = httpMock.expectOne(`${environment.xeroApiConfig.mockDataUrlPrefix}invoices.json`);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockXeroInvoicesResponse); // Respond with the wrapped structure
+    });
+
+     it('should return hardcoded mock invoices if mockDataUrlPrefix is not set but API endpoint is', (done) => {
+      environment.xeroApiConfig.mockDataUrlPrefix = undefined;
+      spyOn(console, 'warn');
+      const hardcoded = (service as any).getHardcodedMockXeroInvoices();
+
+      service.fetchInvoicesFromXero().subscribe(invoices => {
+        expect(invoices.length).toBe(hardcoded.length);
+        expect(console.warn).toHaveBeenCalledWith('XeroService: Actual API call for fetchInvoicesFromXero not implemented. Returning mock data.');
+        if(hardcoded.length > 0) {
+            expect(invoices[0].InvoiceID).toEqual(hardcoded[0].InvoiceID);
+        }
+        done();
+      });
+    });
+
+
+    it('should return hardcoded mock invoices if neither mockDataUrlPrefix nor API endpoint is set', (done) => {
+        environment.xeroApiConfig.mockDataUrlPrefix = undefined;
+        environment.xeroApiConfig.endpoint = undefined;
+        spyOn(console, 'error');
+        const hardcoded = (service as any).getHardcodedMockXeroInvoices();
+
+        service.fetchInvoicesFromXero().subscribe(invoices => {
+          expect(invoices.length).toBe(hardcoded.length);
+          expect(console.error).toHaveBeenCalledWith('XeroService: No API endpoint or mock data URL for Xero. Returning hardcoded mock invoices.');
+          if(hardcoded.length > 0) {
+            expect(invoices[0].InvoiceID).toEqual(hardcoded[0].InvoiceID);
+          }
+          done();
+        });
+      });
+
+    it('should return an empty array on HTTP error when using mockDataUrlPrefix', (done) => {
+      service.fetchInvoicesFromXero().subscribe(invoices => {
+        expect(invoices).toEqual([]);
+        done();
+      });
+      const req = httpMock.expectOne(`${environment.xeroApiConfig.mockDataUrlPrefix}invoices.json`);
+      req.flush('Simulated HTTP error', { status: 500, statusText: 'Server Error' });
+    });
+
+    it('should handle cases where Invoices property might be missing in mock file response', (done) => {
+        service.fetchInvoicesFromXero().subscribe(invoices => {
+          expect(invoices).toEqual([]); // Should default to empty array
+          done();
+        });
+        const req = httpMock.expectOne(`${environment.xeroApiConfig.mockDataUrlPrefix}invoices.json`);
+        req.flush({}); // Empty object instead of {Invoices: []}
+      });
+  });
+
+  describe('syncPaymentsToXero', () => {
+    it('should simulate success and log (mock)', (done) => {
+      spyOn(console, 'warn'); // Assuming endpoint is set by default from beforeEach
+      service.syncPaymentsToXero([{ id: 'pay1' }]).subscribe(result => {
+        expect(result).toBe(true);
+        expect(console.warn).toHaveBeenCalledWith('XeroService: Actual API call for syncPaymentsToXero not implemented. Simulating success.');
+        done();
+      });
+    });
+  });
+
+  describe('syncContactsToXero', () => {
+    it('should simulate success and log (mock)', (done) => {
+      environment.xeroApiConfig.endpoint = undefined; // Test the other path
+      spyOn(console, 'log');
+      const contacts = [{ id: 'contact1' }];
+      service.syncContactsToXero(contacts).subscribe(result => {
+        expect(result).toBe(true);
+        expect(console.log).toHaveBeenCalledWith('XeroService: Simulating contact sync to Xero (mock). Data:', contacts);
+        done();
+      });
+    });
+  });
+});

--- a/src/app/modules/services/xero.service.ts
+++ b/src/app/modules/services/xero.service.ts
@@ -1,0 +1,153 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+
+// Define interfaces for Xero data structures (simplified)
+// These would be based on Xero API responses
+
+interface RawXeroInvoice {
+  InvoiceID?: string;
+  InvoiceNumber?: string;
+  Type: 'ACCREC' | 'ACCPAY'; // Accounts Receivable or Payable
+  Contact: {
+    ContactID?: string;
+    Name?: string;
+  };
+  DateString?: string; // YYYY-MM-DD
+  DueDateString?: string; // YYYY-MM-DD
+  LineItems?: Array<{
+    Description?: string;
+    Quantity?: number;
+    UnitAmount?: number;
+    AccountCode?: string;
+    LineAmount?: number;
+  }>;
+  SubTotal?: number;
+  TotalTax?: number;
+  Total?: number;
+  AmountDue?: number;
+  Status?: string; // e.g., "DRAFT", "SUBMITTED", "AUTHORISED", "PAID"
+}
+
+interface RawXeroPayment {
+  PaymentID?: string;
+  Date?: string; // YYYY-MM-DD
+  Invoice?: {
+    InvoiceID: string;
+    InvoiceNumber?: string;
+  };
+  Account?: { // Bank account payment is made from/to
+    Code: string;
+  };
+  Amount: number;
+  // ... other payment fields
+}
+
+interface RawXeroContact {
+  ContactID?: string;
+  Name?: string;
+  EmailAddress?: string;
+  Addresses?: Array<{
+    AddressType?: string; // e.g., "POBOX", "STREET"
+    AddressLine1?: string;
+    City?: string;
+    Region?: string; // State/Province
+    PostalCode?: string;
+    Country?: string;
+  }>;
+  // ... other contact fields
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class XeroService {
+  private xeroApiEndpoint = environment.xeroApiConfig?.endpoint;
+  private mockDataUrlPrefix = environment.xeroApiConfig?.mockDataUrlPrefix; // e.g., /assets/mocks/xero-
+
+  constructor(private http: HttpClient) {
+    if (!this.xeroApiEndpoint && !this.mockDataUrlPrefix) {
+      console.warn('XeroService: API endpoint or mockDataUrlPrefix is not configured.');
+    }
+  }
+
+  // --- Invoice Synchronization ---
+  // Pushes your application's invoices to Xero
+  syncInvoicesToXero(invoices: any[] /* App's Invoice model */): Observable<boolean> {
+    if (this.xeroApiEndpoint) {
+      console.warn('XeroService: Actual API call for syncInvoicesToXero not implemented. Simulating success.');
+      // TODO: Implement actual POST/PUT to this.xeroApiEndpoint/Invoices
+      // This would involve transforming your app's invoice model to RawXeroInvoice
+      return of(true);
+    } else {
+      console.log('XeroService: Simulating invoice sync to Xero (mock). Data:', invoices);
+      return of(true);
+    }
+  }
+
+  // Fetches invoices from Xero
+  fetchInvoicesFromXero(): Observable<RawXeroInvoice[]> {
+    if (this.mockDataUrlPrefix) {
+      return this.http.get<{Invoices: RawXeroInvoice[]}>(`${this.mockDataUrlPrefix}invoices.json`).pipe(
+        map(response => response.Invoices || []), // Xero often wraps arrays in a root object
+        catchError(err => {
+          console.error('Error fetching mock Xero invoices:', err);
+          return of([]);
+        })
+      );
+    } else if (this.xeroApiEndpoint) {
+      console.warn('XeroService: Actual API call for fetchInvoicesFromXero not implemented. Returning mock data.');
+      // TODO: Implement actual GET from this.xeroApiEndpoint/Invoices
+      return of(this.getHardcodedMockXeroInvoices());
+    } else {
+      console.error('XeroService: No API endpoint or mock data URL for Xero. Returning hardcoded mock invoices.');
+      return of(this.getHardcodedMockXeroInvoices());
+    }
+  }
+
+  // --- Payment Synchronization ---
+  syncPaymentsToXero(payments: any[] /* App's Payment model */): Observable<boolean> {
+    if (this.xeroApiEndpoint) {
+      console.warn('XeroService: Actual API call for syncPaymentsToXero not implemented. Simulating success.');
+      // TODO: Implement actual POST/PUT to this.xeroApiEndpoint/Payments
+      return of(true);
+    } else {
+      console.log('XeroService: Simulating payment sync to Xero (mock). Data:', payments);
+      return of(true);
+    }
+  }
+
+  // --- Contact (Customer) Synchronization ---
+  syncContactsToXero(contacts: any[] /* App's Customer/Contact model */): Observable<boolean> {
+    if (this.xeroApiEndpoint) {
+      console.warn('XeroService: Actual API call for syncContactsToXero not implemented. Simulating success.');
+      // TODO: Implement actual POST/PUT to this.xeroApiEndpoint/Contacts
+      return of(true);
+    } else {
+      console.log('XeroService: Simulating contact sync to Xero (mock). Data:', contacts);
+      return of(true);
+    }
+  }
+
+  private getHardcodedMockXeroInvoices(): RawXeroInvoice[] {
+    return [
+      {
+        InvoiceID: "xero-inv-123", InvoiceNumber: "XINV001", Type: "ACCREC",
+        Contact: { ContactID: "xero-contact-456", Name: "Xero Customer Alpha" },
+        DateString: "2023-02-10", DueDateString: "2023-03-10",
+        LineItems: [{ Description: "Consulting Services", Quantity: 10, UnitAmount: 150, AccountCode: "200", LineAmount: 1500 }],
+        SubTotal: 1500, TotalTax: 150, Total: 1650, AmountDue: 1650, Status: "AUTHORISED"
+      },
+      {
+        InvoiceID: "xero-inv-124", InvoiceNumber: "XINV002", Type: "ACCREC",
+        Contact: { ContactID: "xero-contact-789", Name: "Xero Customer Beta" },
+        DateString: "2023-02-15", DueDateString: "2023-03-15",
+        LineItems: [{ Description: "Product Sale", Quantity: 2, UnitAmount: 300, AccountCode: "200", LineAmount: 600 }],
+        SubTotal: 600, TotalTax: 60, Total: 660, AmountDue: 0, Status: "PAID"
+      }
+    ];
+  }
+  // Add similar getHardcodedMockXeroPayments, getHardcodedMockXeroContacts if needed
+}


### PR DESCRIPTION
- Implemented initial mock services and connector components for:
  - Marketplaces: Amazon (new), eBay (enhanced), Shopify (reviewed)
  - Accounting: QuickBooks (new), Xero (new)
  - Shipping: FedEx (new), UPS (new), Shippo (new)

- Each integration includes a service with mock API calls and a corresponding Angular component for UI interaction.
- Updated the IntegrationsModule to declare new components, add routes, and include ReactiveFormsModule.
- Enhanced the integrations landing page to list and navigate to all new integration connector UIs.
- Added basic unit test spec files for all new services and components, focusing on mock service interactions and component logic.
- Considered and documented decision against a generic external order transformation service for now, favoring specific service transformation to a common model.