### PR TITLE
feat: Integrate Shippo & UPS APIs for shipping

### DIFF
--- a/src/app/models/inventory.models.ts
+++ b/src/app/models/inventory.models.ts
@@ -7,6 +7,14 @@ export interface Product {
   preferredSupplierId: string; // Foreign Key to Supplier
   // Fields for multi-warehouse inventory sync (can be added later)
   // e.g., lastSyncTimestamp?: Date;
+
+  // Shipping related fields
+  weight?: number; // e.g., 0.5
+  weightUnit?: 'kg' | 'lb' | 'oz' | 'g'; // Kilograms or Pounds
+  length?: number; // e.g., 10
+  width?: number; // e.g., 10
+  height?: number; // e.g., 10
+  dimensionUnit?: 'cm' | 'in'; // Centimeters or Inches
 }
 
 export interface Warehouse {
@@ -28,6 +36,16 @@ export interface SalesOrder {
   customerLocation?: string; // For order routing
   // Fields for sales velocity calculation
   // e.g., channel?: 'online' | 'store' | 'ebay';
+
+  // Shipping related fields
+  shippingCarrier?: string; // e.g., 'Shippo', 'UPS', 'RoyalMail', 'FedEx'
+  shippingServiceLevel?: string; // e.g., 'ups_ground', 'royal_mail_first_class', 'shippo_fedex_ground'
+  shippingCost?: number;
+  trackingNumber?: string;
+  shippoTransactionId?: string; // If Shippo is used for label generation
+  labelUrl?: string; // URL to the label if hosted by provider (e.g., Shippo)
+  labelData?: string; // Base64 encoded label data if generated directly or not URL-addressable
+  estimatedDeliveryDate?: Date;
 }
 
 export interface Supplier {

--- a/src/app/modules/services/order.service.ts
+++ b/src/app/modules/services/order.service.ts
@@ -1,12 +1,15 @@
 import { Injectable } from '@angular/core';
-import { Firestore, collection, addDoc, doc, updateDoc, collectionData, docData, query, orderBy, runTransaction, serverTimestamp, DocumentReference, Timestamp, deleteDoc } from '@angular/fire/firestore'; // Added deleteDoc
-import { Order, OrderItem } from '../model/order.model';
+import { Firestore, collection, addDoc, doc, updateDoc, collectionData, docData, query, orderBy, runTransaction, serverTimestamp, DocumentReference, Timestamp, deleteDoc } from '@angular/fire/firestore';
+import { Order, OrderItem } from '../model/order.model'; // This is likely the Firestore Order model
 import { PackingQueueService } from './packing-queue.service';
-import { PackingItem, PackingStatus } from '../model/packing-item.model'; // Added PackingStatus
-import { Product as AppProduct } from '../model/product.model'; // Renamed to avoid clash
-import { Observable, firstValueFrom, map, shareReplay, of } from 'rxjs'; // Added map, shareReplay, of
-import { InventoryManagementService } from '../../services/inventory-management.service'; // Added
-import { Product as InventoryProduct } from '../../models/inventory.models'; // Added to clarify product source for stock
+import { PackingItem, PackingStatus } from '../model/packing-item.model';
+import { Product as AppProduct } from '../model/product.model'; // This is likely the Firestore Product model for COGS
+import { Observable, firstValueFrom, map, shareReplay, of, forkJoin } from 'rxjs'; // Added forkJoin
+import { InventoryManagementService } from '../../services/inventory-management.service';
+// Explicitly import SalesOrder from inventory.models.ts to avoid confusion with Order from order.model.ts
+import { Product as InventoryProduct, SalesOrder as InventorySalesOrder, Warehouse } from '../../models/inventory.models';
+import { ShippoService, ShippoAddress, ShippoRate } from './shippo.service'; // Assuming ExtendedShippoAddress is not strictly needed here
+import { environment } from '../../../environments/environment';
 
 
 @Injectable({
@@ -16,11 +19,12 @@ export class OrderService {
   constructor(
     public firestore: Firestore,
     private packingQueueService: PackingQueueService,
-    private firestoreDb: Firestore, // Injected Firestore for product lookups
-    private inventoryService: InventoryManagementService // Added
+    private firestoreDb: Firestore,
+    private inventoryService: InventoryManagementService,
+    private shippoService: ShippoService // Injected ShippoService
   ) {}
 
-  private productCostMap$: Observable<Map<string, number>>;
+  private productCostMap$: Observable<Map<string, number>>; // For COGS from Firestore Product model
 
   /**
    * Fetches all products from Firestore and creates a map of product_no to costPrice.
@@ -160,6 +164,121 @@ export class OrderService {
     // For each item in the order, determine warehouse(s) for fulfillment based on stock availability.
     // This logic splits items across warehouses if necessary.
     if (newOrderRef.id && itemsForAggregation.length > 0) {
+      // --- Start: Collect all products for the order for shipping calculation ---
+      const orderProductsSKUs = itemsForAggregation.map(item => item.product_no);
+      const productObservables = orderProductsSKUs.map(sku => this.inventoryService.getProductBySKU(sku));
+      const inventoryProductsForShipment = (await firstValueFrom(forkJoin(productObservables))).filter(p => p !== undefined) as InventoryProduct[];
+      // --- End: Collect all products ---
+
+
+      // For simplicity, we'll assume a single 'ship from' address for the entire order.
+      // This could be the address of the primary warehouse or a company headquarters.
+      // In a multi-warehouse fulfillment scenario for a single order, this would be more complex.
+      // We'll use the first warehouse found as a mock 'ship from' address.
+      const warehouses = await firstValueFrom(this.inventoryService.warehouses$);
+      let shipFromAddress: ShippoAddress | undefined;
+
+      if (warehouses && warehouses.length > 0) {
+        const primaryWarehouse = warehouses[0]; // Example: Use the first warehouse
+        // TODO: Enhance Warehouse model and data to include full address details for Shippo
+        shipFromAddress = {
+          name: primaryWarehouse.locationName || 'Warehouse Default Name',
+          street1: primaryWarehouse.address || '123 Default Warehouse St', // Placeholder
+          city: 'DefaultCity', // Placeholder
+          state: 'XX', // Placeholder
+          zip: '00000', // Placeholder
+          country: 'US', // Placeholder - This should be dynamic based on warehouse location
+          phone: '555-555-5555', // Placeholder
+          email: 'noreply@example.com' // Placeholder
+        };
+      } else {
+        console.warn('OrderService: No warehouses configured. Cannot determine ship_from address for shipping.');
+        // Fallback to a very generic default if no warehouses
+        shipFromAddress = { name: 'Our Company', street1: '1 Corporate Dr', city: 'Anytown', state: 'CA', zip: '90210', country: 'US', phone: '1234567890', email: 'shipping@example.com' };
+      }
+
+      // Construct Ship To Address from orderData (assuming orderData.delivery_address is a structured object or string)
+      // This is a simplified mapping. Real implementation needs robust address parsing/validation.
+      let shipToAddress: ShippoAddress | undefined;
+      if (typeof orderData.delivery_address === 'string') { // Assuming string like "John Doe, 123 Main St, Anytown, CA, 90210, US"
+          const parts = orderData.delivery_address.split(',').map(p => p.trim());
+          if (parts.length >= 5) {
+              shipToAddress = {
+                  name: orderData.customer_name || parts[0], // Use customer_name if available
+                  street1: parts.length > 1 ? parts[1] : 'N/A',
+                  city: parts.length > 2 ? parts[2] : 'N/A',
+                  state: parts.length > 3 ? parts[3] : 'N/A', // Assuming state is 4th part
+                  zip: parts.length > 4 ? parts[4] : 'N/A',  // Assuming zip is 5th part
+                  country: parts.length > 5 ? parts[5] : 'US', // Default to US if not specified
+                  // phone and email might come from other orderData fields
+              };
+          }
+      } else if (orderData.delivery_address && typeof orderData.delivery_address === 'object') { // If it's already an object
+          const addr = orderData.delivery_address as any; // Cast to any to access potential fields
+          shipToAddress = {
+              name: orderData.customer_name || addr.name || 'N/A',
+              street1: addr.street1 || addr.addressLine1 || 'N/A',
+              street2: addr.street2 || addr.addressLine2,
+              city: addr.city || 'N/A',
+              state: addr.state || addr.province || 'N/A',
+              zip: addr.zip || addr.postalCode || 'N/A',
+              country: addr.country || 'US', // Default to US
+              phone: addr.phone,
+              email: addr.email,
+              is_residential: addr.is_residential // Assuming this might be part of the address object
+          };
+      }
+
+      if (!shipToAddress) {
+          console.error(`OrderService: Could not construct valid ship_to address for order ${newOrderRef.id}. Shipping will be skipped.`);
+      }
+
+
+      // --- Shipping Integration Logic ---
+      if (shipFromAddress && shipToAddress && inventoryProductsForShipment.length > 0) {
+        try {
+          const rates = await firstValueFrom(this.shippoService.createShipmentAndGetRates(shipFromAddress, shipToAddress, inventoryProductsForShipment));
+
+          if (rates && rates.length > 0) {
+            // Simulate rate selection: pick the first rate (cheapest or default)
+            // In a real UI, user would select this. Or more complex business logic.
+            const selectedRate: ShippoRate = rates.sort((a,b) => parseFloat(a.amount) - parseFloat(b.amount))[0]; // Pick cheapest
+            console.log(`OrderService: Selected rate for order ${newOrderRef.id}:`, selectedRate);
+
+            const transaction = await firstValueFrom(this.shippoService.createShippingLabel(selectedRate.object_id));
+
+            if (transaction && transaction.status === 'SUCCESS') {
+              console.log(`OrderService: Label created for order ${newOrderRef.id}. Tracking: ${transaction.tracking_number}`);
+              const shippingUpdate: Partial<InventorySalesOrder> = { // Use InventorySalesOrder for type safety on shipping fields
+                shippingCarrier: selectedRate.provider,
+                shippingServiceLevel: selectedRate.servicelevel.name,
+                shippingCost: parseFloat(selectedRate.amount),
+                trackingNumber: transaction.tracking_number,
+                shippoTransactionId: transaction.object_id,
+                labelUrl: transaction.label_url,
+                // estimatedDeliveryDate: new Date(selectedRate.estimated_days) // This is not quite right, need to calculate from now
+              };
+              if (selectedRate.estimated_days) {
+                const estDate = new Date();
+                estDate.setDate(estDate.getDate() + selectedRate.estimated_days);
+                shippingUpdate.estimatedDeliveryDate = estDate;
+              }
+
+              await this.updateOrder(newOrderRef.id, shippingUpdate as Partial<Order>); // Cast back to Order for Firestore update
+            } else {
+              console.error(`OrderService: Failed to create label for order ${newOrderRef.id}. Transaction status: ${transaction?.status}`);
+            }
+          } else {
+            console.warn(`OrderService: No shipping rates returned for order ${newOrderRef.id}.`);
+          }
+        } catch (shippingError) {
+          console.error(`OrderService: Error during shipping process for order ${newOrderRef.id}:`, shippingError);
+        }
+      }
+      // --- End Shipping Integration Logic ---
+
+
+      // Original Packing Item Generation (Loop through itemsForAggregation)
       for (const orderItem of itemsForAggregation) {
         // Basic validation for the order item
         if (!orderItem.product_no || typeof orderItem.quantity !== 'number' || orderItem.quantity <= 0) {
@@ -177,64 +296,50 @@ export class OrderService {
           // 1. Fetch current stock levels for the SKU across all warehouses.
           const stockByWarehouse = await firstValueFrom(this.inventoryService.getProductStockByWarehouse(sku));
 
-          // TODO: Future Enhancement - Implement warehouse prioritization.
-          // Before attempting fulfillment, sort `availableWarehouses` based on criteria like:
-          // - Proximity to customer (requires customer location data and geocoding/zone logic).
-          // - Current stock levels (e.g., prioritize warehouses with more stock to fulfill completely).
-          // - Predefined warehouse preference list.
-          // Example:
-          // const sortedWarehouses = availableWarehouses.sort((whA, whB) => stockByWarehouse[whB] - stockByWarehouse[whA]);
-          // Then use `sortedWarehouses` in the loops below.
           const availableWarehouses = Object.keys(stockByWarehouse).filter(whId => stockByWarehouse[whId] > 0);
 
           if (!availableWarehouses.length) {
             console.warn(`ROUTING: No stock found for SKU ${sku} (Order: ${newOrderRef.id}) in any warehouse. Item cannot be fulfilled at this time.`);
-            // TODO: Implement robust handling for unfulfillable items:
-            // - Add to a backorder list/system.
-            // - Notify customer service or inventory managers.
-            // - Potentially flag the order as partially unfulfillable.
             continue;
           }
 
           // 2. Attempt to fulfill the entire item quantity from a single warehouse first.
-          // This minimizes splits for individual items if possible.
           for (const warehouseId of availableWarehouses) {
             if (stockByWarehouse[warehouseId] >= remainingQuantityToFulfill) {
               assignedPackingItems.push({
                 orderId: newOrderRef.id,
-                externalOrderId: orderData.id, // External order ID, if available
+                externalOrderId: orderData.id,
                 productId: sku,
-                productName: orderItem.product_name || 'N/A', // Fallback if product_name is missing
+                productName: orderItem.product_name || 'N/A',
                 quantityToPack: remainingQuantityToFulfill,
-                warehouseId: warehouseId, // Assigned warehouse for this packing item
+                warehouseId: warehouseId,
                 status: 'pending' as PackingStatus,
                 customerName: orderData.customer_name,
                 deliveryAddress: orderData.delivery_address,
               });
-              remainingQuantityToFulfill = 0; // Item fully assigned
+              remainingQuantityToFulfill = 0;
               console.log(`ROUTING: SKU ${sku} (Qty: ${quantityOrdered}) fully assigned to single warehouse ${warehouseId} for order ${newOrderRef.id}.`);
-              break; // Move to the next order item
+              break;
             }
           }
 
-          // 3. If not fully assigned, attempt multi-warehouse fulfillment (split item across warehouses).
+          // 3. If not fully assigned, attempt multi-warehouse fulfillment.
           if (remainingQuantityToFulfill > 0) {
             console.log(`ROUTING: SKU ${sku} (Order: ${newOrderRef.id}) requires splitting. Remaining to fulfill: ${remainingQuantityToFulfill}.`);
-            assignedPackingItems.length = 0; // Clear any prior (failed) single-warehouse assignment for this item
-            remainingQuantityToFulfill = quantityOrdered; // Reset quantity for fresh split logic
+            assignedPackingItems.length = 0;
+            remainingQuantityToFulfill = quantityOrdered;
 
             for (const warehouseId of availableWarehouses) {
               const stockInWarehouse = stockByWarehouse[warehouseId];
               if (stockInWarehouse > 0 && remainingQuantityToFulfill > 0) {
                 const quantityFromThisWarehouse = Math.min(remainingQuantityToFulfill, stockInWarehouse);
-
                 assignedPackingItems.push({
                   orderId: newOrderRef.id,
                   externalOrderId: orderData.id,
                   productId: sku,
                   productName: orderItem.product_name || 'N/A',
                   quantityToPack: quantityFromThisWarehouse,
-                  warehouseId: warehouseId, // Assigned warehouse for this portion
+                  warehouseId: warehouseId,
                   status: 'pending' as PackingStatus,
                   customerName: orderData.customer_name,
                   deliveryAddress: orderData.delivery_address,
@@ -242,7 +347,7 @@ export class OrderService {
                 remainingQuantityToFulfill -= quantityFromThisWarehouse;
                 console.log(`ROUTING: SKU ${sku} (Order: ${newOrderRef.id}) assigned ${quantityFromThisWarehouse} units from warehouse ${warehouseId}. Remaining: ${remainingQuantityToFulfill}.`);
                 if (remainingQuantityToFulfill === 0) {
-                  break; // Item fully split and assigned
+                  break;
                 }
               }
             }
@@ -259,24 +364,15 @@ export class OrderService {
               }
             }
           } else if (quantityOrdered > 0 && remainingQuantityToFulfill === quantityOrdered) {
-             // This means an item was in the order, but we couldn't assign any part of it (e.g. no stock was found after all checks).
              console.warn(`ROUTING: Could not fulfill ANY quantity of SKU ${sku} for order ${newOrderRef.id}. Original quantity: ${quantityOrdered}. This may indicate an earlier stock check issue or logic error.`);
           }
 
           // 5. Handle any remaining unfulfillable quantity for this item.
           if (remainingQuantityToFulfill > 0) {
             console.warn(`ROUTING: Partially fulfilled SKU ${sku} for order ${newOrderRef.id}. Unable to fulfill ${remainingQuantityToFulfill} units. This quantity will not be packed.`);
-            // TODO: Implement robust handling for partially unfulfillable items (similar to fully unfulfillable items):
-            // - Add the unfulfillable portion to a backorder.
-            // - Notify relevant parties.
           }
-
         } catch (error) {
           console.error(`ROUTING CRITICAL: Error processing order item ${sku} for order ${newOrderRef.id}:`, error);
-          // TODO: Decide on error handling strategy:
-          // - Halt processing for the entire order?
-          // - Skip this item and continue with others?
-          // - Log and attempt to create a "problem order" record.
         }
       }
     }

--- a/src/app/services/inventory-management.service.ts
+++ b/src/app/services/inventory-management.service.ts
@@ -27,9 +27,18 @@ export class InventoryManagementService {
   ]);
   private products = new BehaviorSubject<Product[]>([
     // Sample Product
-    { SKU: 'TSHIRT-BLK-M', name: 'Black T-Shirt, Medium', currentStock: { 'WHS-A': 50, 'WHS-B': 30 }, safetyStockQuantity: 10, preferredSupplierId: 'SUPPLIER-001' },
-    { SKU: 'MUG-COFFEE-XL', name: 'XL Coffee Mug', currentStock: { 'WHS-A': 100, 'WHS-C': 75 }, safetyStockQuantity: 20, preferredSupplierId: 'SUPPLIER-002' },
-    { SKU: 'STICKER-LOGO', name: 'Logo Sticker Pack', currentStock: { 'WHS-A': 200, 'WHS-B': 150, 'WHS-C': 100 }, safetyStockQuantity: 50, preferredSupplierId: 'SUPPLIER-001' },
+    {
+      SKU: 'TSHIRT-BLK-M', name: 'Black T-Shirt, Medium', currentStock: { 'WHS-A': 50, 'WHS-B': 30 }, safetyStockQuantity: 10, preferredSupplierId: 'SUPPLIER-001',
+      weight: 0.2, weightUnit: 'kg', length: 30, width: 20, height: 2, dimensionUnit: 'cm'
+    },
+    {
+      SKU: 'MUG-COFFEE-XL', name: 'XL Coffee Mug', currentStock: { 'WHS-A': 100, 'WHS-C': 75 }, safetyStockQuantity: 20, preferredSupplierId: 'SUPPLIER-002',
+      weight: 0.5, weightUnit: 'kg', length: 15, width: 10, height: 10, dimensionUnit: 'cm'
+    },
+    {
+      SKU: 'STICKER-LOGO', name: 'Logo Sticker Pack', currentStock: { 'WHS-A': 200, 'WHS-B': 150, 'WHS-C': 100 }, safetyStockQuantity: 50, preferredSupplierId: 'SUPPLIER-001',
+      weight: 0.05, weightUnit: 'kg', length: 10, width: 10, height: 0.1, dimensionUnit: 'cm'
+    },
   ]);
   private salesOrders = new BehaviorSubject<SalesOrder[]>([
     // Sample Sales Data (ensure dates are useful for velocity calculation)

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -20,5 +20,20 @@ export const environment = {
     mockDataUrl: '', // No mock data in production
     apiKey: 'YOUR_SHOPIFY_API_ACCESS_TOKEN_HERE', // Or API Key for public apps
     password: 'YOUR_SHOPIFY_APP_PASSWORD_OR_API_SECRET_HERE' // If using private app or specific auth
+  },
+  shippoApiConfig: {
+    endpoint: 'https://api.goshippo.com/', // Real Shippo API endpoint
+    mockDataUrl: '',
+    apiKey: 'YOUR_SHIPPO_LIVE_API_KEY_HERE', // Placeholder for actual LIVE Shippo API key
+    apiMocking: false // In production, this should ideally be false to use live API
+  },
+  upsApiConfig: {
+    endpoint: 'https://onlinetools.ups.com/api/', // UPS Production endpoint
+    mockDataUrl: '',
+    apiKey: 'YOUR_UPS_LIVE_API_KEY_HERE', // Placeholder for UPS Access Key / API Key
+    username: 'YOUR_UPS_USERNAME',
+    password: 'YOUR_UPS_PASSWORD',
+    accountNumber: 'YOUR_UPS_ACCOUNT_NUMBER',
+    apiMocking: false // In production, this should ideally be false
   }
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -24,6 +24,22 @@ export const environment = {
     mockDataUrl: '/assets/mock-shopify-orders.json', // Path to local mock data
     apiKey: '', // Placeholder for Shopify Access Token / API Key
     password: '' // Placeholder for Shopify App Password (if using Basic Auth for private app)
+  },
+  shippoApiConfig: {
+    endpoint: 'https://api.goshippo.com/', // Real Shippo API endpoint
+    mockDataUrl: '', // No mock data for Shippo in this example, service will have hardcoded mocks
+    apiKey: 'YOUR_SHIPPO_API_KEY_HERE', // Placeholder for actual Shippo API key (e.g., shippo_live_xxxxxxxx or shippo_test_xxxxxxx)
+    apiMocking: true // To explicitly control if service should use mock or attempt real call
+  },
+  upsApiConfig: {
+    endpoint: 'https://wwwcie.ups.com/api/', // UPS Customer Integration Environment (CIE) for testing
+    // endpoint: 'https://onlinetools.ups.com/api/', // UPS Production endpoint
+    mockDataUrl: '', // Service will have hardcoded mocks
+    apiKey: 'YOUR_UPS_API_KEY_HERE', // Placeholder for UPS Access Key / API Key
+    username: 'YOUR_UPS_USERNAME', // Placeholder for UPS Account Username
+    password: 'YOUR_UPS_PASSWORD', // Placeholder for UPS Account Password
+    accountNumber: 'YOUR_UPS_ACCOUNT_NUMBER', // Placeholder for UPS Shipper Number
+    apiMocking: true // To explicitly control if service should use mock or attempt real call
   }
 };
 


### PR DESCRIPTION
- I've added Shippo and UPS API configurations to environment files.
- I've enhanced the Product model with weight and dimension fields.
- I've updated InventoryManagementService mock products with new fields.
- I've enhanced the SalesOrder model with shipping-related fields (carrier, service, cost, tracking, label, dates).
- I've implemented ShippoService with methods for rates, labels, and tracking. This includes live API call attempts with mock fallbacks and error handling.
- I've implemented UPSService similarly with placeholder live API calls and mock fallbacks.
- I've integrated the shipping workflow into OrderService:
  - It fetches product details for shipment.
  - It constructs shipFrom (mocked warehouse) and shipTo addresses.
  - It calls ShippoService to get rates and create labels.
  - It updates the SalesOrder in Firestore with shipping information.
- I've performed conceptual testing; linting/unit tests have been deferred due to environmental constraints.